### PR TITLE
fix: concurrenct queue should not stack trace on error

### DIFF
--- a/src/commands/copy/copy-worker.ts
+++ b/src/commands/copy/copy-worker.ts
@@ -6,7 +6,6 @@ import { baseLogger } from '../../log.js';
 import { ConcurrentQueue } from '../../utils/concurrent.queue.js';
 import { registerCli } from '../common.js';
 import { CopyContract, CopyContractArgs, CopyStats } from './copy-rpc.js';
-import * as timers from 'node:timers/promises';
 
 const Q = new ConcurrentQueue(10);
 

--- a/src/commands/copy/copy-worker.ts
+++ b/src/commands/copy/copy-worker.ts
@@ -6,6 +6,7 @@ import { baseLogger } from '../../log.js';
 import { ConcurrentQueue } from '../../utils/concurrent.queue.js';
 import { registerCli } from '../common.js';
 import { CopyContract, CopyContractArgs, CopyStats } from './copy-rpc.js';
+import * as timers from 'node:timers/promises';
 
 const Q = new ConcurrentQueue(10);
 
@@ -32,6 +33,7 @@ const worker = new WorkerRpc<CopyContract>({
           }
 
           if (!args.force) {
+            log.error({ target: target.path, source: source.path }, 'File:Overwrite');
             throw new Error('Cannot overwrite file: ' + todo.target + ' source:' + todo.source);
           }
         }

--- a/src/utils/concurrent.queue.ts
+++ b/src/utils/concurrent.queue.ts
@@ -20,6 +20,6 @@ export class ConcurrentQueue {
 
   /** Wait for all tasks to finish */
   async join(): Promise<void> {
-    while (this.todo.size > 0) await this.todo.values().next().value;
+    await Promise.all([...this.todo.values()]);
   }
 }


### PR DESCRIPTION
should fix us seeing stack traces without context

```

node:internal/event_target:1006
  process.nextTick(() => { throw err; });
                           ^
Error: Cannot overwrite file: s3://linz-workflow-artifacts/2022-12/15-imagery-standardising-v0.2.0-60-l8jb8/flat/BC35_5000_0206.tiff source:s3://linz
-workflow-artifacts/2022-12/15-imagery-standardising-v0.2.0-60-l8jb8/imagery-standardising-v0.2.0-60-l8jb8-standardise-validate-4104332785/tmp/BC35_5
000_0206.tiff
    at file:///app/commands/copy/copy-worker.js:32:31
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Emitted 'error' event on Worker instance at:
    at [kOnErrorMessage] (node:internal/worker:290:10)
    at [kOnMessage] (node:internal/worker:301:37)
    at MessagePort.<anonymous> (node:internal/worker:202:57)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:731:20)
    at exports.emitMessage (node:internal/per_context/messageport:23:28)

Node.js v18.12.0
```