### PR TITLE
ci: dep upgrades are not features

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  commit-message:
-    prefix: "feat"
-    prefix-development: "build"
-    include: "scope"
   open-pull-requests-limit: 10


### PR DESCRIPTION
dependency upgrades were coming through as "feat" showing up in the change log.