### PR TITLE
ci: gh packages should show the GIT_VERSION_MAJOR_MINOR version first TDE-610

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,11 +41,11 @@ jobs:
           GIT_VERSION_MAJOR_MINOR=$(echo $GIT_VERSION | cut -d. -f1,2)
 
           docker tag argo-tasks ghcr.io/linz/argo-tasks:latest
-          docker tag argo-tasks ghcr.io/linz/argo-tasks:${GIT_VERSION}
-          docker tag argo-tasks ghcr.io/linz/argo-tasks:${GIT_VERSION_MAJOR}
           docker tag argo-tasks ghcr.io/linz/argo-tasks:${GIT_VERSION_MAJOR_MINOR}
-
+          docker tag argo-tasks ghcr.io/linz/argo-tasks:${GIT_VERSION_MAJOR}
+          docker tag argo-tasks ghcr.io/linz/argo-tasks:${GIT_VERSION}
+          
           docker push ghcr.io/linz/argo-tasks:latest
-          docker push ghcr.io/linz/argo-tasks:${GIT_VERSION}
-          docker push ghcr.io/linz/argo-tasks:${GIT_VERSION_MAJOR}
           docker push ghcr.io/linz/argo-tasks:${GIT_VERSION_MAJOR_MINOR}
+          docker push ghcr.io/linz/argo-tasks:${GIT_VERSION_MAJOR}
+          docker push ghcr.io/linz/argo-tasks:${GIT_VERSION}


### PR DESCRIPTION
## Description
From some tests, it seems that the order of publishing the tags matters to make sure GitHub Packages `Install from the command line` shows the `vX.Y.Z` like in this example:
![image](https://user-images.githubusercontent.com/86932794/213273311-af964f8e-2327-4a8f-b451-bd117a2e0518.png)
