### PR TITLE
ci: use docker push --all-tags to avoid multiple push TDE-626

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,5 +25,4 @@ jobs:
           docker tag argo-tasks ghcr.io/linz/argo-tasks:latest
           docker tag argo-tasks ghcr.io/linz/argo-tasks:${GIT_VERSION}
 
-          docker push ghcr.io/linz/argo-tasks:latest
-          docker push ghcr.io/linz/argo-tasks:${GIT_VERSION}
+          docker push --all-tags ghcr.io/linz/argo-tasks

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,4 @@ jobs:
           docker tag argo-tasks ghcr.io/linz/argo-tasks:${GIT_VERSION_MAJOR_MINOR}
           docker tag argo-tasks ghcr.io/linz/argo-tasks:${GIT_VERSION}
           
-          docker push ghcr.io/linz/argo-tasks:latest
-          docker push ghcr.io/linz/argo-tasks:${GIT_VERSION_MAJOR}
-          docker push ghcr.io/linz/argo-tasks:${GIT_VERSION_MAJOR_MINOR}
-          docker push ghcr.io/linz/argo-tasks:${GIT_VERSION}
+          docker push --all-tags ghcr.io/linz/argo-tasks


### PR DESCRIPTION
Use --all-tags flag in order to avoid falling into a rate limit by pushing multiple tags in sequence
Same change for `topo-imagery` https://github.com/linz/topo-imagery/pull/315