### PR TITLE
feat(copy): log errors in child workers as composite error reasons get swallowed TDE-637

### DIFF
--- a/src/commands/copy/copy-worker.ts
+++ b/src/commands/copy/copy-worker.ts
@@ -45,7 +45,11 @@ const worker = new WorkerRpc<CopyContract>({
         stats.copiedBytes += source.size;
       });
     }
-    await Q.join();
+    await Q.join().catch((err) => {
+      // Composite errors get swallowed when rethrown through worker threads
+      log.fatal({ err }, 'File:Copy:Failed');
+      throw err;
+    });
     return stats;
   },
 });


### PR DESCRIPTION
When throwning in a child worker the composite error's "reason" gets lost, and makes it hard to know why the error was thrown.
