### PR TITLE
fix: stop using alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:18-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
We have having intermittent DNS failures with "getaddrinfo EAI_AGAIN"