### PR TITLE
build: ignore aws sdk patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "@aws-sdk/*"
+      update-types: ["version-update:semver-patch"]
+    - dependency-name: "@types/node"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
they happen far to often and create too much noise.