### PR TITLE
fix: stac-validate --recursive fails with local path TDE-732

### DIFF
--- a/src/commands/stac-validate/__test__/stac.validate.test.ts
+++ b/src/commands/stac-validate/__test__/stac.validate.test.ts
@@ -1,5 +1,5 @@
 import o from 'ospec';
-import { listLocation, iri, iriReference, getStacSchemaUrl, normaliseHref } from '../stac.validate.js';
+import { listLocation, iri, iriReference, getStacSchemaUrl, normaliseHref, isURL } from '../stac.validate.js';
 
 o.spec('stacValidate', function () {
   o('listLocation', async function () {
@@ -48,9 +48,18 @@ o.spec('stacValidate', function () {
   o('getStacSchemaUrlInvalidStacType', async function () {
     o(getStacSchemaUrl('CollectionItem', '1.0.0', 'placeholder path')).equals(null);
   });
+  o('isURL', async function () {
+    o(isURL('s3://test-bucket/test-survey/collection.json')).equals(true);
+    o(isURL('data/test-survey/collection.json')).equals(false);
+  });
   o('normaliseHref', async function () {
     o(normaliseHref('./item.json', 's3://test-bucket/test-survey/collection.json')).equals(
       's3://test-bucket/test-survey/item.json',
     );
+    o(normaliseHref('./item.json', 'data/test-survey/collection.json')).equals('data/test-survey/item.json');
+    o(normaliseHref('./sub-folder/item.json', 'data/test-survey/collection.json')).equals(
+      'data/test-survey/sub-folder/item.json',
+    );
+    o(normaliseHref('./item.json', 'collection.json')).equals('item.json');
   });
 });

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -2,7 +2,7 @@ import { fsa } from '@chunkd/fs';
 import Ajv, { DefinedError, SchemaObject, ValidateFunction } from 'ajv';
 import { fastFormats } from 'ajv-formats/dist/formats.js';
 import { boolean, command, flag, number, option, restPositionals, string } from 'cmd-ts';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import { performance } from 'perf_hooks';
 import * as st from 'stac-ts';
 import { logger } from '../../log.js';
@@ -268,7 +268,19 @@ export function getStacChildren(stacJson: st.StacItem | st.StacCollection | st.S
 }
 
 export function normaliseHref(href: string, path: string): string {
-  return new URL(href, path).href;
+  if (isURL(path)) {
+    return new URL(href, path).href;
+  }
+  return join(path.substring(0, path.lastIndexOf('/')), href);
+}
+
+export function isURL(path: string): boolean {
+  try {
+    new URL(path);
+    return true;
+  } catch (err) {
+    return false;
+  }
 }
 
 // Handle list of lists that results from using the 'list' command to supply location

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -271,7 +271,7 @@ export function normaliseHref(href: string, path: string): string {
   if (isURL(path)) {
     return new URL(href, path).href;
   }
-  return join(path.substring(0, path.lastIndexOf('/')), href);
+  return join(dirname(path), href);
 }
 
 export function isURL(path: string): boolean {


### PR DESCRIPTION
Calling `stac-validate --recursive` would fail using a local path:
```
{"level":30,"time":1681767643384,"pid":1,"hostname":"7efca33c9249","id":"01GY8JKDVG22VPN5JQK0XFGKY5","msg":"StacValidation:Start"}
{"level":30,"time":1[6](https://github.com/paulfouquet/argo-tasks-test/actions/runs/4726094077/jobs/8385289001#step:4:7)81[7](https://github.com/paulfouquet/argo-tasks-test/actions/runs/4726094077/jobs/8385289001#step:4:8)67643700,"pid":1,"hostname":"7efca33c9249","id":"01GY8JKDVG22VPN5JQK0XFGKY5","type":"Catalog","path":"data/stac/catalog.json","msg":"Validation:Done:Ok"}
{"level":50,"time":16[8](https://github.com/paulfouquet/argo-tasks-test/actions/runs/4726094077/jobs/8385289001#step:4:9)1767643700,"pid":1,"hostname":"7efca33c[9](https://github.com/paulfouquet/argo-tasks-test/actions/runs/4726094077/jobs/8385289001#step:4:10)249","id":"01GY8JKDVG22VPN5JQK0XFGKY5","err":{"type":"TypeError","message":"Invalid URL","stack":"TypeError [ERR_INVALID_URL]: Invalid URL\n    at new NodeError (node:internal/errors:399:5)\n    at new URL (node:internal/url:560:13)\n    at normaliseHref (file:///app/commands/stac-validate/stac.validate.js:288:12)\n    at file:///app/commands/stac-validate/stac.validate.js:280:78\n    at Array.map (<anonymous>)\n    at getStacChildren (file:///app/commands/stac-validate/stac.validate.js:280:67)\n    at validateStac (file:///app/commands/stac-validate/stac.validate.js:184:37)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)","input":"./collection.json","code":"ERR_INVALID_URL"},"msg":"Failed"}
{"level":50,"time":1681767643702,"pid":1,"hostname":"7efca33c9249","id":"01GY8JKDVG22VPN5JQK0XFGKY5","failures":1,"msg":"StacValidation:Done:Failed"}
```