### PR TITLE
feat: include git version info in container

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: linz/action-typescript@v3
 
-      - name: Setup tags
+      - name: Setup GIT version
         id: version
         run: |
           GIT_VERSION=$(git describe --tags --always --match 'v*')
@@ -35,11 +35,11 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ steps.version.outputs.version }} 
 
-      - name: Build and push
+      - name: Build and container
         uses: docker/build-push-action@v4
         with:
           context: .
-          tags: argo-tasks
+          tags: base
           push: false
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -48,46 +48,38 @@ jobs:
             GITHUB_RUN_ID=${{ github.run_id}}
 
       - name: Login to GitHub Container Registry
+        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v4
+      - name: Publish Containers to GHCR
+        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        run: |
+          docker tag base ghcr.io/${{ github.repository }}:latest
+          docker tag base ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
+
+          docker push --all-tags ghcr.io/${{ github.repository }}
+
+      - name: Configure AWS Credentials
+        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          context: .
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
-          push: true
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            GIT_HASH=${{ github.sha }}
-            GIT_VERSION=${{ steps.version.outputs.version }} 
-            GITHUB_RUN_ID=${{ github.run_id}}
+          aws-region: ap-southeast-2
+          mask-aws-account-id: true
+          role-to-assume: ${{ secrets.AWS_CI_ROLE }}
 
+      - name: Login to Amazon ECR
+        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
-      # - name: Configure AWS Credentials
-      #   if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-      #   uses: aws-actions/configure-aws-credentials@v2
-      #   with:
-      #     aws-region: ap-southeast-2
-      #     mask-aws-account-id: true
-      #     role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+      - name: Publish Containers to ECR
+        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        run: |
+          docker tag base ${{ steps.login-ecr.outputs.registry }}/eks:argo-tasks-latest
+          docker tag base ${{ steps.login-ecr.outputs.registry }}/eks:argo-tasks-${{ steps.version.outputs.version }}
 
-      # - name: Login to Amazon ECR
-      #   if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-      #   id: login-ecr
-      #   uses: aws-actions/amazon-ecr-login@v1
-
-      # - name: Publish Containers to ECR
-      #   if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-      #   env:
-      #     REGISTRY: ${{ steps.login-ecr.outputs.registry }}/eks
-      #     TAG: argo-tasks
-      #   run: |
-      #     docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-latest
-      #     docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION }}
-
-      #     docker push --all-tags ${{ env.REGISTRY }}
+          docker push --all-tags ${{ steps.login-ecr.outputs.registry }}/eks

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
+          context: .
           tags: argo-tasks
           push: false
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,14 +13,36 @@ jobs:
     steps:
       - uses: linz/action-typescript@v3
 
-      - name: Build containers
+      - name: Setup tags
+        id: version
         run: |
-          docker build . \
-          --tag argo-tasks \
-          --label "github_run_id=${GITHUB_RUN_ID}" \
-          --build-arg GIT_HASH=${{ github.sha }} \
-          --build-arg GIT_VERSION=$(git describe --tags --always --match 'v*') \
-          --build-arg GITHUB_RUN_ID=${GITHUB_RUN_ID}
+          GIT_VERSION=$(git describe --tags --always --match 'v*')
+          GIT_VERSION_MAJOR=$(echo $GIT_VERSION | cut -d. -f1)
+          GIT_VERSION_MAJOR_MINOR=$(echo $GIT_VERSION | cut -d. -f1,2)
+
+          echo "version=${GIT_VERSION}" >> $GITHUB_OUTPUT
+          echo "version_major=${GIT_VERSION_MAJOR}" >> $GITHUB_OUTPUT
+          echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          tags: argo-tasks
+          push: false
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args:
+            GIT_HASH=${{ github.sha }}
+            GIT_VERSION=${{ steps.version.outputs.version }} 
+            GITHUB_RUN_ID=${{ github.run_id}}
 
       - name: Log in to registry
         if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,43 +47,48 @@ jobs:
             GIT_VERSION=${{ steps.version.outputs.version }} 
             GITHUB_RUN_ID=${{ github.run_id}}
 
-      - name: Log in to registry
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-
-      - name: Publish Containers to GHCR
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-        env:
-          TAG: argo-tasks
-        run: |
-          GIT_VERSION=$(git describe --tags --always --match 'v*')
-          echo "GIT_VERSION=$GIT_VERSION" >> $GITHUB_ENV
-
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:latest
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION}
-
-          docker push --all-tags ghcr.io/linz/${{ env.TAG }}
-
-      - name: Configure AWS Credentials
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          aws-region: ap-southeast-2
-          mask-aws-account-id: true
-          role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Amazon ECR
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
+          push: false
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_HASH=${{ github.sha }}
+            GIT_VERSION=${{ steps.version.outputs.version }} 
+            GITHUB_RUN_ID=${{ github.run_id}}
 
-      - name: Publish Containers to ECR
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}/eks
-          TAG: argo-tasks
-        run: |
-          docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-latest
-          docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION }}
 
-          docker push --all-tags ${{ env.REGISTRY }}
+      # - name: Configure AWS Credentials
+      #   if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+      #   uses: aws-actions/configure-aws-credentials@v2
+      #   with:
+      #     aws-region: ap-southeast-2
+      #     mask-aws-account-id: true
+      #     role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+
+      # - name: Login to Amazon ECR
+      #   if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+      #   id: login-ecr
+      #   uses: aws-actions/amazon-ecr-login@v1
+
+      # - name: Publish Containers to ECR
+      #   if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+      #   env:
+      #     REGISTRY: ${{ steps.login-ecr.outputs.registry }}/eks
+      #     TAG: argo-tasks
+      #   run: |
+      #     docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-latest
+      #     docker tag ${{ env.TAG}} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION }}
+
+      #     docker push --all-tags ${{ env.REGISTRY }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,11 @@ jobs:
 
       - name: Build containers
         run: |
-          docker build . --tag argo-tasks --label "github_run_id=${GITHUB_RUN_ID}"
+          docker build . \
+          --tag argo-tasks \
+          --label "github_run_id=${GITHUB_RUN_ID}" \
+          --build-arg GIT_HASH=${{ github.sha }} \
+          --build-arg GIT_VERSION=$(git describe --tags --always --match 'v*')
 
       - name: Log in to registry
         if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,9 +59,8 @@ jobs:
         with:
           context: .
           tags: |
-            ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
-          push: false
+          push: true
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_HASH=${{ github.sha }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,8 @@ jobs:
           --tag argo-tasks \
           --label "github_run_id=${GITHUB_RUN_ID}" \
           --build-arg GIT_HASH=${{ github.sha }} \
-          --build-arg GIT_VERSION=$(git describe --tags --always --match 'v*')
+          --build-arg GIT_VERSION=$(git describe --tags --always --match 'v*') \
+          --build-arg GITHUB_RUN_ID=${GITHUB_RUN_ID}
 
       - name: Log in to registry
         if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,6 +32,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ github.repository }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }} 
 
       - name: Build and push
         uses: docker/build-push-action@v4
@@ -39,7 +41,7 @@ jobs:
           tags: argo-tasks
           push: false
           labels: ${{ steps.meta.outputs.labels }}
-          build-args:
+          build-args: |
             GIT_HASH=${{ github.sha }}
             GIT_VERSION=${{ steps.version.outputs.version }} 
             GITHUB_RUN_ID=${{ github.run_id}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,11 @@ jobs:
 
       - name: Build containers
         run: |
-          docker build . --tag argo-tasks --label "github_run_id=${GITHUB_RUN_ID}"
+          docker build . \
+            --tag argo-tasks \
+            --label "github_run_id=${GITHUB_RUN_ID}" \
+            --build-arg GIT_HASH=${{ github.sha }} \
+            --build-arg GIT_VERSION=$(git describe --tags --always --match 'v*')
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,10 +30,11 @@ jobs:
       - name: Build containers
         run: |
           docker build . \
-            --tag argo-tasks \
-            --label "github_run_id=${GITHUB_RUN_ID}" \
-            --build-arg GIT_HASH=${{ github.sha }} \
-            --build-arg GIT_VERSION=$(git describe --tags --always --match 'v*')
+          --tag argo-tasks \
+          --label "github_run_id=${GITHUB_RUN_ID}" \
+          --build-arg GIT_HASH=${{ github.sha }} \
+          --build-arg GIT_VERSION=$(git describe --tags --always --match 'v*') \
+          --build-arg GITHUB_RUN_ID=${GITHUB_RUN_ID}
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,35 +27,55 @@ jobs:
     steps:
       - uses: linz/action-typescript@v3
 
-      - name: Build containers
-        run: |
-          docker build . \
-          --tag argo-tasks \
-          --label "github_run_id=${GITHUB_RUN_ID}" \
-          --build-arg GIT_HASH=${{ github.sha }} \
-          --build-arg GIT_VERSION=$(git describe --tags --always --match 'v*') \
-          --build-arg GITHUB_RUN_ID=${{ github.run_id}}
-
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-
-      - name: Publish Containers to GHCR
-        env:
-          TAG: argo-tasks
+      - name: Setup GIT version
+        id: version
         run: |
           GIT_VERSION=$(git describe --tags --always --match 'v*')
           GIT_VERSION_MAJOR=$(echo $GIT_VERSION | cut -d. -f1)
           GIT_VERSION_MAJOR_MINOR=$(echo $GIT_VERSION | cut -d. -f1,2)
-          echo "GIT_VERSION=$GIT_VERSION" >> $GITHUB_ENV
-          echo "GIT_VERSION_MAJOR=$GIT_VERSION_MAJOR" >> $GITHUB_ENV
-          echo "GIT_VERSION_MAJOR_MINOR=$GIT_VERSION_MAJOR_MINOR" >> $GITHUB_ENV
 
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:latest
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION_MAJOR}
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION_MAJOR_MINOR}
-          docker tag ${{ env.TAG }} ghcr.io/linz/${{ env.TAG }}:${GIT_VERSION}
+          echo "version=${GIT_VERSION}" >> $GITHUB_OUTPUT
+          echo "version_major=${GIT_VERSION_MAJOR}" >> $GITHUB_OUTPUT
+          echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }} 
+
+      - name: Build and container
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          tags: base
+          push: false
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_HASH=${{ github.sha }}
+            GIT_VERSION=${{ steps.version.outputs.version }} 
+            GITHUB_RUN_ID=${{ github.run_id}}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Containers to GHCR
+        run: |
+          docker tag base ghcr.io/${{ github.repository }}:latest
+          docker tag base ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version_major }}
+          docker tag base ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version_major_minor }}
+          docker tag base ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
           
-          docker push --all-tags ghcr.io/linz/${{ env.TAG }}
+          docker push --all-tags ghcr.io/${{ github.repository }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -69,13 +89,10 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Publish Containers to ECR
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}/eks
-          TAG: argo-tasks
         run: |
-          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-latest
-          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION_MAJOR }}
-          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION_MAJOR_MINOR }}
-          docker tag ${{ env.TAG }} ${{ env.REGISTRY }}:${{ env.TAG }}-${{ env.GIT_VERSION }}
+          docker tag base ${{ steps.login-ecr.outputs.registry }}/eks:argo-tasks-latest
+          docker tag base ${{ steps.login-ecr.outputs.registry }}/eks:argo-tasks-${{ steps.version.outputs.version_major }}
+          docker tag base ${{ steps.login-ecr.outputs.registry }}/eks:argo-tasks-${{ steps.version.outputs.version_major_minor }}
+          docker tag base ${{ steps.login-ecr.outputs.registry }}/eks:argo-tasks-${{ steps.version.outputs.version }}
 
-          docker push --all-tags ${{ env.REGISTRY }}
+          docker push --all-tags ${{ steps.login-ecr.outputs.registry }}/eks

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
           --label "github_run_id=${GITHUB_RUN_ID}" \
           --build-arg GIT_HASH=${{ github.sha }} \
           --build-arg GIT_VERSION=$(git describe --tags --always --match 'v*') \
-          --build-arg GITHUB_RUN_ID=${GITHUB_RUN_ID}
+          --build-arg GITHUB_RUN_ID=${{ github.run_id}}
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ RUN apt-get update && apt-get install openssh-client git -y
 
 WORKDIR /app
 
+ARG GIT_VERSION
+ENV GIT_VERSION ${GIT_VERSION}
+
+ARG GIT_HASH=unknown
+ENV GIT_HASH ${GIT_HASH}
+
+RUN echo "GitInfo version:'${GIT_VERSION}' hash:'${GIT_HASH}'"
+
 ENV NODE_ENV production
 
 ADD package.json package-lock.json /app/

--- a/src/cli.info.ts
+++ b/src/cli.info.ts
@@ -1,0 +1,5 @@
+export const CliInfo = {
+  package: '@linz/argo-tasks',
+  version: process.env['GIT_VERSION'],
+  hash: process.env['GIT_HASH'],
+};

--- a/src/cli.info.ts
+++ b/src/cli.info.ts
@@ -1,5 +1,9 @@
 export const CliInfo = {
-  package: '@linz/argo-tasks',
+  package: '@linzjs/argo-tasks',
+  // Git version information
   version: process.env['GIT_VERSION'],
+  // Git commit hash
   hash: process.env['GIT_HASH'],
+  // Github action that the CLI was built from
+  runId: process.env['GITHUB_RUN_ID'],
 };

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -1,6 +1,8 @@
 import { boolean, flag, option, optional, string } from 'cmd-ts';
 import { registerFileSystem } from '../fs.register.js';
-import { registerLogger } from '../log.js';
+import { logger, registerLogger } from '../log.js';
+import { CliInfo } from '../cli.info.js';
+import { isArgo } from '../utils/argo.js';
 
 export const config = option({
   long: 'config',
@@ -21,10 +23,12 @@ export const forceOutput = flag({
   defaultValueIsSerializable: true,
 });
 
-export function registerCli(args: { verbose?: boolean; config?: string }): void {
+export function registerCli(cli: { name: string }, args: { verbose?: boolean; config?: string }): void {
   cleanArgs(args);
   registerLogger(args);
   registerFileSystem(args);
+
+  logger.info({ package: CliInfo, cli: cli.name, args, isArgo: isArgo() }, 'Cli:Start');
 }
 
 /** Trim any extra special characters from the cli parser */

--- a/src/commands/copy/copy-worker.ts
+++ b/src/commands/copy/copy-worker.ts
@@ -81,7 +81,7 @@ const worker = new WorkerRpc<CopyContract>({
 });
 
 worker.onStart = async (): Promise<void> => {
-  registerCli({});
+  registerCli({ name: 'copy:worker' }, {});
 };
 
 if (parentPort) worker.bind(parentPort);

--- a/src/commands/copy/copy.ts
+++ b/src/commands/copy/copy.ts
@@ -55,8 +55,8 @@ export const commandCopy = command({
     concurrency: option({ type: number, long: 'concurrency', defaultValue: () => 4 }),
     manifest: restPositionals({ type: string, displayName: 'location', description: 'Manifest of file to copy' }),
   },
-  handler: async (args) => {
-    registerCli(args);
+  async handler(args) {
+    registerCli(this, args);
 
     const workerUrl = new URL('./copy-worker.js', import.meta.url);
     const pool = new WorkerRpcPool<CopyContract>(args.concurrency, workerUrl);

--- a/src/commands/copy/copy.ts
+++ b/src/commands/copy/copy.ts
@@ -8,6 +8,7 @@ import { logger, logId } from '../../log.js';
 import { ActionCopy } from '../../utils/actions.js';
 import { config, registerCli, verbose } from '../common.js';
 import { CopyContract } from './copy-rpc.js';
+import { CliInfo } from '../../cli.info.js';
 
 const CopyValidator = z.object({ source: z.string(), target: z.string() });
 const CopyManifest = z.array(CopyValidator);
@@ -31,6 +32,7 @@ async function tryParse(x: string): Promise<unknown> {
 export const commandCopy = command({
   name: 'copy',
   description: 'Copy a manifest of files',
+  version: CliInfo.version,
   args: {
     config,
     verbose,

--- a/src/commands/create-manifest/create-manifest.ts
+++ b/src/commands/create-manifest/create-manifest.ts
@@ -7,10 +7,12 @@ import { getActionLocation } from '../../utils/action.storage.js';
 import { ActionCopy } from '../../utils/actions.js';
 import { FileFilter, getFiles } from '../../utils/chunk.js';
 import { config, registerCli, verbose } from '../common.js';
+import { CliInfo } from '../../cli.info.js';
 
 export const commandCreateManifest = command({
   name: 'create-manifest',
   description: 'Create a list of files to copy and pass as a manifest',
+  version: CliInfo.version,
   args: {
     config,
     verbose,

--- a/src/commands/create-manifest/create-manifest.ts
+++ b/src/commands/create-manifest/create-manifest.ts
@@ -38,8 +38,8 @@ export const commandCreateManifest = command({
     target: option({ type: string, long: 'target', description: 'Copy destination' }),
     source: restPositionals({ type: string, displayName: 'source', description: 'Where to list' }),
   },
-  handler: async (args) => {
-    registerCli(args);
+  async handler(args) {
+    registerCli(this, args);
 
     const outputCopy: string[] = [];
 

--- a/src/commands/group/group.ts
+++ b/src/commands/group/group.ts
@@ -53,8 +53,8 @@ export const commandGroup = command({
   name: 'group',
   description: 'group a array of inputs into a set ',
   args: CommandGroupArgs,
-  handler: async (args) => {
-    registerCli(args);
+  async handler(args) {
+    registerCli(this, args);
 
     const inputs: unknown[] = [];
     for (const input of args.inputs) inputs.push(...loadInput(input));

--- a/src/commands/group/group.ts
+++ b/src/commands/group/group.ts
@@ -3,6 +3,7 @@ import { command, number, option, optional, restPositionals, string } from 'cmd-
 import { logger } from '../../log.js';
 import { isArgo } from '../../utils/argo.js';
 import { config, forceOutput, registerCli, verbose } from '../common.js';
+import { CliInfo } from '../../cli.info.js';
 
 /** Chunk an array into a group size
  * @example
@@ -51,6 +52,7 @@ export const CommandGroupArgs = {
 
 export const commandGroup = command({
   name: 'group',
+  version: CliInfo.version,
   description: 'group a array of inputs into a set ',
   args: CommandGroupArgs,
   async handler(args) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,9 +9,11 @@ import { commandStacValidate } from './stac-validate/stac.validate.js';
 import { commandTileIndexValidate } from './tileindex-validate/tileindex.validate.js';
 import { commandStacGithubImport } from './stac-github-import/stac.github.import.js';
 import { commandGroup } from './group/group.js';
+import { CliInfo } from '../cli.info.js';
 
 export const cmd = subcommands({
   name: 'argo-tasks',
+  version: CliInfo.version,
   description: 'Utility tasks for argo',
   cmds: {
     copy: commandCopy,

--- a/src/commands/lds-cache/lds.cache.ts
+++ b/src/commands/lds-cache/lds.cache.ts
@@ -19,8 +19,8 @@ export const commandLdsFetch = command({
     layers: restPositionals({ type: string, description: 'Layer id and optional version "layer@version"' }),
     target: option({ type: string, long: 'target', description: 'Target directory to save files' }),
   },
-  handler: async (args) => {
-    registerCli(args);
+  async handler(args) {
+    registerCli(this, args);
 
     for (const layer of args.layers) {
       const [layerId, layerVersion] = layer.split('@');

--- a/src/commands/lds-cache/lds.cache.ts
+++ b/src/commands/lds-cache/lds.cache.ts
@@ -4,6 +4,7 @@ import * as stac from 'stac-ts';
 import { createGunzip } from 'zlib';
 import { logger } from '../../log.js';
 import { config, registerCli, verbose } from '../common.js';
+import { CliInfo } from '../../cli.info.js';
 
 function getTargetPath(source: string, path: string): string {
   if (path.startsWith('./')) return fsa.join(source, path.slice(2));
@@ -12,6 +13,7 @@ function getTargetPath(source: string, path: string): string {
 
 export const commandLdsFetch = command({
   name: 'lds-fetch-layer',
+  version: CliInfo.version,
   description: 'Download a LDS layer from the LDS Cache',
   args: {
     config,

--- a/src/commands/list/list.ts
+++ b/src/commands/list/list.ts
@@ -28,8 +28,8 @@ export const commandList = command({
   name: 'list',
   description: 'List and group files into collections of tasks',
   args: CommandListArgs,
-  handler: async (args) => {
-    registerCli(args);
+  async handler(args) {
+    registerCli(this, args);
     if (args.location.length === 0) {
       logger.error('List:Error:NoLocationProvided');
       process.exit(1);

--- a/src/commands/list/list.ts
+++ b/src/commands/list/list.ts
@@ -3,6 +3,7 @@ import { command, number, option, optional, restPositionals, string } from 'cmd-
 import { logger } from '../../log.js';
 import { getFiles } from '../../utils/chunk.js';
 import { config, registerCli, verbose } from '../common.js';
+import { CliInfo } from '../../cli.info.js';
 
 export const CommandListArgs = {
   config,
@@ -26,6 +27,7 @@ export const CommandListArgs = {
 
 export const commandList = command({
   name: 'list',
+  version: CliInfo.version,
   description: 'List and group files into collections of tasks',
   args: CommandListArgs,
   async handler(args) {

--- a/src/commands/stac-catalog/stac.catalog.ts
+++ b/src/commands/stac-catalog/stac.catalog.ts
@@ -54,8 +54,8 @@ export const commandStacCatalog = command({
     path: positional({ type: string, description: 'Location to search for collection.json paths' }),
   },
 
-  handler: async (args) => {
-    registerCli(args);
+  async handler(args) {
+    registerCli(this, args);
     logger.info('StacCatalogCreation:Start');
     const catalog = await fsa.readJson<st.StacCatalog>(args.template);
     if (catalog.stac_extensions == null) catalog.stac_extensions = [];

--- a/src/commands/stac-catalog/stac.catalog.ts
+++ b/src/commands/stac-catalog/stac.catalog.ts
@@ -5,6 +5,7 @@ import * as st from 'stac-ts';
 import { logger } from '../../log.js';
 import { config, registerCli, verbose } from '../common.js';
 import { createHash } from 'crypto';
+import { CliInfo } from '../../cli.info.js';
 
 /** is a path a URL */
 export function isUrl(path: string): boolean {
@@ -42,6 +43,7 @@ const StacFileExtensionUrl = 'https://stac-extensions.github.io/file/v2.1.0/sche
 export const commandStacCatalog = command({
   name: 'stac-catalog',
   description: 'Construct STAC catalog',
+  version: CliInfo.version,
   args: {
     config,
     verbose,

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import * as st from 'stac-ts';
 import { config, registerCli, verbose } from '../common.js';
 import { logger } from '../../log.js';
+import { CliInfo } from '../../cli.info.js';
 
 const Url: Type<string, URL> = {
   async from(str) {
@@ -15,6 +16,7 @@ const Url: Type<string, URL> = {
 export const commandStacGithubImport = command({
   name: 'stac-github-import',
   description: 'Format and push a stac collection.json file to GitHub repository',
+  version: CliInfo.version,
   args: {
     config,
     verbose,

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -39,8 +39,8 @@ export const commandStacGithubImport = command({
     }),
   },
 
-  handler: async (args) => {
-    registerCli(args);
+  async handler(args) {
+    registerCli(this, args);
 
     const gitName = process.env['GIT_AUTHOR_NAME'] ?? 'imagery[bot]';
     const gitEmail = process.env['GIT_AUTHOR_EMAIL'] ?? 'imagery@linz.govt.nz';

--- a/src/commands/stac-sync/stac.sync.ts
+++ b/src/commands/stac-sync/stac.sync.ts
@@ -4,6 +4,7 @@ import { logger } from '../../log.js';
 import { config, registerCli, verbose } from '../common.js';
 import { createHash } from 'crypto';
 import { FileInfo } from '@chunkd/core';
+import { CliInfo } from '../../cli.info.js';
 
 const S3Path: Type<string, URL> = {
   async from(str) {
@@ -15,6 +16,7 @@ const S3Path: Type<string, URL> = {
 export const commandStacSync = command({
   name: 'stac-sync',
   description: 'Sync STAC files',
+  version: CliInfo.version,
   args: {
     config,
     verbose,

--- a/src/commands/stac-sync/stac.sync.ts
+++ b/src/commands/stac-sync/stac.sync.ts
@@ -25,8 +25,8 @@ export const commandStacSync = command({
     }),
   },
 
-  handler: async (args) => {
-    registerCli(args);
+  async handler(args) {
+    registerCli(this, args);
     logger.info({ source: args.sourcePath, destination: args.destinationPath }, 'StacSync:Start');
     const nb = await synchroniseFiles(args.sourcePath, args.destinationPath);
     logger.info({ copied: nb }, 'StacSync:Done');

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -47,8 +47,8 @@ export const commandStacValidate = command({
     }),
   },
 
-  handler: async (args) => {
-    registerCli(args);
+  async handler(args) {
+    registerCli(this, args);
 
     logger.info('StacValidation:Start');
     const Schemas = new Map<string, Promise<SchemaObject>>();

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -9,10 +9,12 @@ import { logger } from '../../log.js';
 import { ConcurrentQueue } from '../../utils/concurrent.queue.js';
 import { config, registerCli, verbose } from '../common.js';
 import { hashStream } from './hash.worker.js';
+import { CliInfo } from '../../cli.info.js';
 
 export const commandStacValidate = command({
   name: 'stac-validate',
   description: 'Validate STAC files',
+  version: CliInfo.version,
   args: {
     config,
     verbose,

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -109,7 +109,7 @@ export const commandTileIndexValidate = command({
     location: restPositionals({ type: string, displayName: 'location', description: 'Location of the source files' }),
   },
   async handler(args) {
-    registerCli(args);
+    registerCli(this, args);
     logger.info('TileIndex:Start');
 
     const readTiffStartTime = performance.now();
@@ -245,8 +245,6 @@ export interface TiffLocation {
  * // --retile=true --validate=false
  * // create a re-tiling output of {tileName, input: string[] }
  *
- *
- *
  * -- Not handled (yet!)
  * input: 1:10_000
  * scale: 1:1000
@@ -354,8 +352,3 @@ export function getTileName(originX: number, originY: number, grid_size: number)
   const tile_id = `${`${tile_y}`.padStart(nb_digits, '0')}${`${tile_x}`.padStart(nb_digits, '0')}`;
   return `${sheet_code}_${grid_size}_${tile_id}`;
 }
-
-// process.exit() // Kill the application early
-
-// input.geojson -> { source: "s3://foo/bar/baz_tif.tiff", outputTile: "BK23_1000_0505.tiff", isDuplicate: true }
-// output.geojson -> { source: ["s3://foo/bar/baz_tif.tiff", ... ], tileName: "BK23_1000_0505.tiff", isDuplicate: true }

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -10,6 +10,7 @@ import { findBoundingBox } from '../../utils/geotiff.js';
 import { MapSheet, SheetRanges } from '../../utils/mapsheet.js';
 import { config, forceOutput, registerCli, verbose } from '../common.js';
 import { CommandListArgs } from '../list/list.js';
+import { CliInfo } from '../../cli.info.js';
 
 const SHEET_MIN_X = MapSheet.origin.x + 4 * MapSheet.width; // The minimum x coordinate of a valid sheet / tile
 const SHEET_MAX_X = MapSheet.origin.x + 46 * MapSheet.width; // The maximum x coordinate of a valid sheet / tile
@@ -85,6 +86,7 @@ export interface FileList {
 export const commandTileIndexValidate = command({
   name: 'tileindex-validate',
   description: 'List input files and validate there are no duplicates.',
+  version: CliInfo.version,
   args: {
     config,
     verbose,

--- a/src/direct/copy.ts
+++ b/src/direct/copy.ts
@@ -22,7 +22,7 @@ s3Fs.credentials.register({
 const q = new ConcurrentQueue(25);
 
 async function main(): Promise<void> {
-  await registerCli({ verbose: true });
+  await registerCli({ name: 'direct' }, { verbose: true });
 
   for await (const source of fsa.details(SourceLocation)) {
     if (source.size === 0) continue;

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,5 @@
-import { PrettyTransform } from 'pretty-json-log';
 import { pino } from 'pino';
+import { PrettyTransform } from 'pretty-json-log';
 import ulid from 'ulid';
 
 export const baseLogger = process.stdout.isTTY ? pino(PrettyTransform.stream()) : pino();


### PR DESCRIPTION
Switching to the docker container lables gives us a bunch of extra information in all of our containers

from `docker inspect ghcr.io/linz/argo-tasks:v2.10.0-14-gec6bfb1`

```json
"Env": [
    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
    "NODE_VERSION=18.16.1",
    "YARN_VERSION=1.22.19",
    "GIT_VERSION=v2.10.0-14-gec6bfb1",
    "GIT_HASH=ec6bfb17e8527856e56b79e00def33ffff6f2907",
    "NODE_ENV=production"
],
"Labels": {
    "org.opencontainers.image.created": "2023-07-12T00:14:32.434Z",
    "org.opencontainers.image.description": "Utility tasks for working with Argo + LINZs AWS accounts",
    "org.opencontainers.image.licenses": "NOASSERTION",
    "org.opencontainers.image.revision": "ec6bfb17e8527856e56b79e00def33ffff6f2907",
    "org.opencontainers.image.source": "https://github.com/linz/argo-tasks",
    "org.opencontainers.image.title": "argo-tasks",
    "org.opencontainers.image.url": "https://github.com/linz/argo-tasks",
    "org.opencontainers.image.version": "v2.10.0-14-gec6bfb1"
}
```