### PR TITLE
feat(group): increase logging for grouping

### DIFF
--- a/src/cli.info.ts
+++ b/src/cli.info.ts
@@ -5,5 +5,5 @@ export const CliInfo = {
   // Git commit hash
   hash: process.env['GIT_HASH'],
   // Github action that the CLI was built from
-  runId: process.env['GITHUB_RUN_ID'],
+  buildId: process.env['GITHUB_RUN_ID'] ? `${process.env['GITHUB_RUN_ID']}-${process.env['GITHUB_RUN_ATTEMPT']}` : '',
 };

--- a/src/commands/group/group.ts
+++ b/src/commands/group/group.ts
@@ -77,11 +77,17 @@ export const commandGroup = command({
       // Write out a file per group into /tmp/group/output/000.json
       for (let i = 0; i < grouped.length; i++) {
         const groupId = String(i).padStart(3, '0');
+        logger.trace('Group:Output:File', {
+          target: `/tmp/group/output/${groupId}.json`,
+          groupId: i,
+          count: grouped[i]?.length,
+        });
         await fsa.write(`/tmp/group/output/${groupId}.json`, JSON.stringify(grouped[i], null, 2));
         items.push(groupId);
       }
 
       // output.json contains ["001","002","003","004","005","006","007"...]
+      logger.debug('Group:Output', { target: '/tmp/group/output.json', groups: items });
       await fsa.write('/tmp/group/output.json', JSON.stringify(items));
     }
   },


### PR DESCRIPTION
#### Why?

When artifact errors occur in argo its hard to figure out exactly what files were written and what is in those files. 

#### Description

This increases the logging to explain exactly which files were written and some information about their contents.

When running argo containers having the exact github action that made the container is very useful, we were loosing the -attempt number so it was not possible to get the exact version number.