### PR TITLE
build: group similar deps into a single build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    aws:
+      patterns:
+        - "@aws-sdk/*"
+    chunkd:
+      patterns:
+        - "@cogeotiff/*"
+        - "@chunkd/*"
   ignore:
     - dependency-name: "@aws-sdk/*"
       update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
#### Motivation

Dependabot tries to update deps one at a time, often this leads to issues where dep updates are somewhat interrelated :eyes: `@aws-sdk/*` which leads to situations where you may have multiple aws-sdk pull requests but none can be merged individually.

#### Modification

This adds the beta grouping feature for `aws-sdk` and `chunkd` as a test to see how well this works.