### PR TITLE
build: group basemaps dep upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   groups:
+    basemaps:
+      patterns:
+        - "@basemaps/*"
     aws:
       patterns:
         - "@aws-sdk/*"


### PR DESCRIPTION
Basemaps `@basemaps/*` upgrades are often related so group them into a single dependabot pull request.