### PR TITLE
feat: add optional --fix-content-type TDE-859

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ LINZ uses [Argo workflows](https://argoproj.github.io/workflows/) for running bu
 - [create-manifest](#create-manifest)
 - [group](#group)
 - [list](#list)
-- [pretty-print](#pretty-print)
+- [format-json](#format-json)
 - [stac catalog](#stac-catalog)
 - [stac github-import](#stac-github-import)
 - [stac sync](#stac-sync)
@@ -68,22 +68,22 @@ list s3://linz-imagery/sample --include ".*.tiff$" --group 10 --group-size 100MB
 list s3://linz-imagery/sample --include ".*.tiff$"  --exclude "BG33.tiff$" --output /tmp/list.json
 ```
 
-### `pretty-print`
+### `format-json`
 
-Format all JSON files within a directory using `prettier`.
+Format all JSON files within a directory using `prettier`. An optional flag `--fix-content-type` allows to set the content-type for s3 object with a value depending on the STAC object type.
 
 #### Example
 
 - Format and overwrite files:
 
 ```bash
-pretty-print source/
+format-json source/ [--fix-content-type]
 ```
 
 - Create a copy of the formatted file in another flatten directory (testing only - does not handle duplicate filenames):
 
 ```bash
-pretty-print source/ --target output/
+format-json source/ --target output/
 ```
 
 ### `create-manifest`

--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -10,7 +10,7 @@ import { TileSetConfigSchema } from '@basemaps/config/build/json/parse.tile.set.
 import { fsa, LogType } from '@basemaps/shared';
 
 import { DEFAULT_PRETTIER_FORMAT } from '../../utils/config.js';
-import { prettyPrint } from '../format/pretty.print.js';
+import { prettyPrint } from '../format/format.json.js';
 import { createPR, GithubApi } from './github.js';
 
 export enum Category {

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -74,3 +74,20 @@ export function parseSize(size: string): number {
   if (isNaN(fileSize)) throw new Error(`Failed to parse: ${size} as a file size`);
   return Math.round(fileSize);
 }
+
+/**
+ * Guess the content type of a STAC file
+ *
+ * - application/geo+json - A STAC Item
+ * - application/json - A STAC Catalog
+ * - application/json - A STAC Collection
+ *
+ * Assumes anything ending with '.json' is a stac item
+ * @see {@link https://github.com/radiantearth/stac-spec/blob/master/catalog-spec/catalog-spec.md#stac-media-types}
+ */
+export function guessStacContentType(path: string): string | undefined {
+  if (path.endsWith('collection.json')) return 'application/json';
+  if (path.endsWith('catalog.json')) return 'application/json';
+  if (path.endsWith('.json')) return 'application/geo+json';
+  return;
+}

--- a/src/commands/format/format.json.ts
+++ b/src/commands/format/format.json.ts
@@ -1,5 +1,5 @@
 import { fsa } from '@chunkd/fs';
-import { command, option, optional, positional, string } from 'cmd-ts';
+import { boolean, command, flag, option, optional, positional, string } from 'cmd-ts';
 import { basename } from 'path';
 import prettier from 'prettier';
 
@@ -7,16 +7,16 @@ import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
 import { getFiles } from '../../utils/chunk.js';
 import { DEFAULT_PRETTIER_FORMAT } from '../../utils/config.js';
-import { config, registerCli, verbose } from '../common.js';
+import { config, guessStacContentType, registerCli, verbose } from '../common.js';
 
 function isJson(x: string): boolean {
   const search = x.toLowerCase();
   return search.endsWith('.json');
 }
 
-export const commandPrettyPrint = command({
-  name: 'pretty-print',
-  description: 'Pretty print JSON files',
+export const commandFormatJson = command({
+  name: 'format-jspon',
+  description: 'Format JSON files',
   version: CliInfo.version,
   args: {
     config,
@@ -26,15 +26,22 @@ export const commandPrettyPrint = command({
       long: 'target',
       description: 'Use if files have to be saved somewhere else instead of overwriting the source (testing)',
     }),
+    fixContentType: flag({
+      type: boolean,
+      defaultValue: () => false,
+      long: 'fix-content-type',
+      description: 'Append a guessed content-type to the S3 object.',
+      defaultValueIsSerializable: true,
+    }),
     path: positional({ type: string, displayName: 'path', description: 'Path of the files to pretty print' }),
   },
 
   async handler(args) {
     registerCli(this, args);
     const startTime = performance.now();
-    logger.info('PrettyPrint:Start');
+    logger.info('FormatJson:Start');
     if (args.target) {
-      logger.info({ target: args.target }, 'PrettyPrint:Info');
+      logger.info({ target: args.target }, 'FormatJson:Info');
     }
 
     const files = await getFiles([args.path]);
@@ -45,8 +52,8 @@ export const commandPrettyPrint = command({
     if (jsonFiles[0]) await fsa.head(jsonFiles[0]);
 
     // format files
-    await Promise.all(jsonFiles.map((f: string) => formatFile(f, args.target)));
-    logger.info({ fileCount: jsonFiles.length, duration: performance.now() - startTime }, 'PrettyPrint:Done');
+    await Promise.all(jsonFiles.map((f: string) => formatFile(f, args.target, args.fixContentType)));
+    logger.info({ fileCount: jsonFiles.length, duration: performance.now() - startTime }, 'FormatJson:Done');
   },
 });
 
@@ -55,16 +62,19 @@ export const commandPrettyPrint = command({
  *
  * @param path of the file to format
  * @param target where to save the output. If not specified, overwrite the original file.
+ * @param fixContentType if true will set the `contentType` with a guessed value. @see guessStacContentType
  */
-export async function formatFile(path: string, target = ''): Promise<void> {
-  logger.debug({ file: path }, 'PrettyPrint:RunPrettier');
+export async function formatFile(path: string, target = '', fixContentType: boolean = false): Promise<void> {
+  logger.debug({ file: path }, 'FormatJson:RunPrettier');
   const prettyPrinted = await prettyPrint(JSON.stringify(await fsa.readJson(path)), DEFAULT_PRETTIER_FORMAT);
   if (target) {
     // FIXME: can be duplicate files
     path = fsa.join(target, basename(path));
   }
+  let meta = {};
+  if (fixContentType) meta = { contentType: guessStacContentType(path) };
 
-  fsa.write(path, Buffer.from(prettyPrinted));
+  fsa.write(path, Buffer.from(prettyPrinted), meta);
 }
 
 /**

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@ import { CliInfo } from '../cli.info.js';
 import { basemapsCreatePullRequest } from './basemaps-github/create-pr.js';
 import { commandCopy } from './copy/copy.js';
 import { commandCreateManifest } from './create-manifest/create-manifest.js';
-import { commandPrettyPrint } from './format/pretty.print.js';
+import { commandFormatJson } from './format/format.json.js';
 import { commandGroup } from './group/group.js';
 import { commandLdsFetch } from './lds-cache/lds.cache.js';
 import { commandList } from './list/list.js';
@@ -46,6 +46,6 @@ export const cmd = subcommands({
         'create-pr': basemapsCreatePullRequest,
       },
     }),
-    'pretty-print': commandPrettyPrint,
+    'format-json': commandFormatJson,
   },
 });

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -8,7 +8,7 @@ import * as st from 'stac-ts';
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
 import { config, registerCli, verbose } from '../common.js';
-import { formatFile } from '../format/pretty.print.js';
+import { formatFile } from '../format/format.json.js';
 
 const Url: Type<string, URL> = {
   async from(str) {

--- a/src/commands/stac-sync/stac.sync.ts
+++ b/src/commands/stac-sync/stac.sync.ts
@@ -5,7 +5,7 @@ import { createHash } from 'crypto';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
-import { config, registerCli, verbose } from '../common.js';
+import { config, guessStacContentType, registerCli, verbose } from '../common.js';
 
 const S3Path: Type<string, URL> = {
   async from(str) {
@@ -84,21 +84,4 @@ export async function uploadFileToS3(sourceFileInfo: FileInfo, path: URL): Promi
   });
   logger.debug({ path: path.href }, 'StacSync:FileUploaded');
   return true;
-}
-
-/**
- * Guess the content type of a STAC file
- *
- * - application/geo+json - A STAC Item
- * - application/json - A STAC Catalog
- * - application/json - A STAC Collection
- *
- * Assumes anything ending with '.json' is a stac item
- * @see {@link https://github.com/radiantearth/stac-spec/blob/master/catalog-spec/catalog-spec.md#stac-media-types}
- */
-function guessStacContentType(path: string): string | undefined {
-  if (path.endsWith('collection.json')) return 'application/json';
-  if (path.endsWith('catalog.json')) return 'application/json';
-  if (path.endsWith('.json')) return 'application/geo+json';
-  return;
 }


### PR DESCRIPTION
### Description
Add an option `--fix-content-type` in `format-json` (previously `pretty-print`) to force the content-type to be updated for json s3 objects.

### Intention
Some of the STAC files (`Item`) have a content-type set to `application/json` instead of `application/geo+json`.

### Checklist
If not applicable, provide explanation of why.

- [ ] Tests updated: no tests for aws objects
- [x] Docs updated
- [x] Issue linked in Title