### PR TITLE
feat(basemaps): Update the create-pr cli to take targets as input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ Fetch a layer from the LDS and download it as GeoPackage.
 - Create a pull request in the basemaps-config repo after imagery layer imported:
 
 ```bash
-bm-create-pr --layer
-{"2193":"s3://linz-basemaps-staging/2193/southland_2023_0.1m/","3857":"s3://linz-basemaps-staging/3857/southland_2023_0.1m/","name":"southland_2023_0.1m","title":"Southland 0.1m Urban Aerial Photos (2023)"}
+bm-create-pr --target
+["s3://linz-basemaps/3857/gisborne-cyclone-gabrielle_2023_0.2m/01HAAYW5NXJMRMBZBHFPCNY71J/","s3://linz-basemaps/2193/gisborne-cyclone-gabrielle_2023_0.2m/01HAAYW5PMJ90MGRSQCB9YPX0W/"]
 ```
 
 Add --individual flag to import layer into standalone individual config file, otherwise import into aerial map.

--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -78,6 +78,8 @@ export const basemapsCreatePullRequest = command({
       layer[info.epsg] = target;
     }
 
+    if (layer.name === '' || layer.title === '') throw new Error('Failed to find the imagery name or title.');
+
     const git = new MakeCogGithub(layer.name, args.repository);
     if (args.vector) await git.updateVectorTileSet('topographic', layer as ConfigLayer, logger);
     else await git.updateRasterTileSet('aerial', layer as ConfigLayer, category, args.individual, logger);

--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -1,17 +1,33 @@
 import { ConfigLayer, standardizeLayerName } from '@basemaps/config';
+import { Epsg, EpsgCode } from '@basemaps/geo';
+import { fsa } from '@basemaps/shared';
 import { boolean, command, flag, oneOf, option, optional, string } from 'cmd-ts';
+import { StacCollection } from 'stac-ts';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
 import { verbose } from '../common.js';
 import { Category, MakeCogGithub, parseCategory } from './make.cog.github.js';
 
+async function parseTargetInfo(target: string): Promise<{ name: string; title: string; epsg: EpsgCode }> {
+  const splits = target.replace('s3://', '').split('/');
+  const epsg = Epsg.tryGet(Number(splits[1]));
+  const name = splits[2];
+  if (epsg == null || name == null) throw new Error(`Invalid target ${target} to parse the epsg and imagery name.`);
+  const collectionPath = fsa.join(target, 'collection.json');
+  const collection = await fsa.readJson<StacCollection>(collectionPath);
+  const title = collection.title;
+  if (title == null) throw new Error(`Failed to get imagery title from collection.json.`);
+
+  return { name: standardizeLayerName(name), epsg: epsg.code, title };
+}
+
 export const CommandCreatePRArgs = {
   verbose,
-  layer: option({
+  target: option({
     type: string,
-    long: 'layer',
-    description: 'Input config layer import into basemaps-config',
+    long: 'target',
+    description: 'New layers locations as array of strings import into basemaps-config',
   }),
   category: option({
     type: optional(oneOf(Object.values(Category))),
@@ -45,20 +61,25 @@ export const basemapsCreatePullRequest = command({
   description: 'Create a github pull request for the import imagery workflow',
   args: CommandCreatePRArgs,
   async handler(args) {
-    const layerStr = args.layer;
+    const target = args.target;
     const category = args.category ? parseCategory(args.category) : Category.Other;
-    let layer: ConfigLayer;
+    let targets: string[];
     try {
-      layer = JSON.parse(layerStr);
+      targets = JSON.parse(target);
     } catch {
       throw new Error('Please provide a valid input layer');
     }
 
-    //Make sure the imagery name is standardized before update the config
-    layer.name = standardizeLayerName(layer.name);
+    const layer: ConfigLayer = { name: '', title: '', category };
+    for (const target of targets) {
+      const info = await parseTargetInfo(target);
+      layer.name = info.name;
+      layer.title = info.title;
+      layer[info.epsg] = target;
+    }
 
     const git = new MakeCogGithub(layer.name, args.repository);
-    if (args.vector) await git.updateVectorTileSet('topographic', layer, logger);
-    else await git.updateRasterTileSet('aerial', layer, category, args.individual, logger);
+    if (args.vector) await git.updateVectorTileSet('topographic', layer as ConfigLayer, logger);
+    else await git.updateRasterTileSet('aerial', layer as ConfigLayer, category, args.individual, logger);
   },
 });

--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -81,7 +81,7 @@ export const basemapsCreatePullRequest = command({
     if (layer.name === '' || layer.title === '') throw new Error('Failed to find the imagery name or title.');
 
     const git = new MakeCogGithub(layer.name, args.repository);
-    if (args.vector) await git.updateVectorTileSet('topographic', layer as ConfigLayer, logger);
-    else await git.updateRasterTileSet('aerial', layer as ConfigLayer, category, args.individual, logger);
+    if (args.vector) await git.updateVectorTileSet('topographic', layer, logger);
+    else await git.updateRasterTileSet('aerial', layer, category, args.individual, logger);
   },
 });


### PR DESCRIPTION
#### Description
This will enable the new cogify workflow to input the targets for creation pull request.



#### Intention
The new cogify will output an array of target s3 location for each imported imagery. We need to parse the layer information for these targets and prepare pull request.



#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
