### PR TITLE
fix(basemaps): Import config types from the file to avoid importing dynamo

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -1,4 +1,5 @@
-import { ConfigLayer, standardizeLayerName } from '@basemaps/config';
+import { ConfigLayer } from '@basemaps/config/build/config/tile.set.js';
+import { standardizeLayerName } from '@basemaps/config/build/json/name.convertor.js';
 import { Epsg, EpsgCode } from '@basemaps/geo';
 import { fsa } from '@chunkd/fs';
 import { boolean, command, flag, oneOf, option, optional, string } from 'cmd-ts';

--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -1,11 +1,9 @@
 import {
-  ConfigId,
   ConfigLayer,
-  ConfigPrefix,
   ConfigTileSetRaster,
   ConfigTileSetVector,
   TileSetType,
-} from '@basemaps/config';
+} from '@basemaps/config/build/config/tile.set.js';
 import { TileSetConfigSchema } from '@basemaps/config/build/json/parse.tile.set.js';
 import { fsa } from '@chunkd/fs';
 
@@ -78,7 +76,7 @@ export class MakeCogGithub {
       layer.maxZoom = 32;
       const tileSet: TileSetConfigSchema = {
         type: TileSetType.Raster,
-        id: ConfigId.prefix(ConfigPrefix.TileSet, layer.name),
+        id: `ts_${layer.name}`,
         title: layer.title,
         background: '#00000000',
         category,


### PR DESCRIPTION
#### Description
Import the types from files directly to stop import dynamo into the bundle file. 


#### Intention
aws-sdk are required when using `@basemaps/shared` package. As this is not required, we should not import the whole package into code.


#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
