### PR TITLE
fix: collection.json is pushed to gh before pretty-printed TDE-893

### DIFF
--- a/src/commands/format/pretty.print.ts
+++ b/src/commands/format/pretty.print.ts
@@ -64,7 +64,7 @@ export async function formatFile(path: string, target = ''): Promise<void> {
     path = fsa.join(target, basename(path));
   }
 
-  fsa.write(path, Buffer.from(prettyPrinted));
+  await fsa.write(path, Buffer.from(prettyPrinted));
 }
 
 /**

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -7,8 +7,9 @@ import * as st from 'stac-ts';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
+import { DEFAULT_PRETTIER_FORMAT } from '../../utils/config.js';
 import { config, registerCli, verbose } from '../common.js';
-import { formatFile } from '../format/pretty.print.js';
+import { prettyPrint } from '../format/pretty.print.js';
 
 const Url: Type<string, URL> = {
   async from(str) {
@@ -85,12 +86,8 @@ export const commandStacGithubImport = command({
     }
 
     // Write the file to targetCollection
-    await fsa.write(collectionPath, JSON.stringify(collection));
-    logger.info({ repo: gitRepo }, 'npm:install');
+    await fsa.write(collectionPath, await prettyPrint(JSON.stringify(collection), DEFAULT_PRETTIER_FORMAT));
 
-    execFileSync('npm', ['install', '--include=dev'], { cwd: gitRepo });
-    // Format the file with prettier
-    await formatFile(collectionPath);
     execFileSync('git', ['add', collectionPath], { cwd: gitRepo });
     logger.info({ path: collectionPath }, 'git:add');
 


### PR DESCRIPTION
#### Description
`formatFile()` does not wait for the file to be written.

#### Intention
Fix https://github.com/linz/imagery/actions/runs/6295092499/job/17087888283

#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title