### PR TITLE
feat: re-point ci to argo-tasks ecr repository

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -68,8 +68,8 @@ jobs:
             tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}');
 
             if ("${{ steps.login-ecr.outputs.registry }}") {
-            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-latest');
-            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-${{ steps.version.outputs.version }}');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:latest');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
             }
             return tags.join(', ')
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -79,10 +79,10 @@ jobs:
             tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}');
 
             if ("${{ steps.login-ecr.outputs.registry }}") {
-            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-latest');
-            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-${{ steps.version.outputs.version_major }}');
-            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-${{ steps.version.outputs.version_major_minor }}');
-            tags.push('${{ steps.login-ecr.outputs.registry }}/eks:${{ github.event.repository.name }}-${{ steps.version.outputs.version }}');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:latest');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version_major }}');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version_major_minor }}');
+            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
             }
             return tags.join(', ')
 


### PR DESCRIPTION
**motivation**
New ecr repositories have been created (https://github.com/linz/topo-aws-infrastructure/pull/206) and we need to deploy our containers to these new locations

**modification**
changed actions to push containers to new repositories.
For example: argo-tasks/latest rather than eks/argo-tasks-latest