### PR TITLE
fix(basemaps): Remove the trailing slash if exists in the target location.

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -121,7 +121,7 @@ export const basemapsCreatePullRequest = command({
         const info = await parseTargetInfo(target, args.individual);
         layer.name = info.name;
         layer.title = info.title;
-        layer[info.epsg] = target;
+        layer[info.epsg] = target.endsWith('/') ? target.slice(0, -1) : target;
         region = info.region;
       }
       layer.category = category;


### PR DESCRIPTION
#### Motivation
The input of targes from cogify will include a trialling slash, we should remove it if exists to make the config file looks consistent.



#### Modification
Check the slash exists and remove.



#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
