### PR TITLE
build: publish arm containers

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,10 @@ jobs:
           echo "version_major=${GIT_VERSION_MAJOR}" >> $GITHUB_OUTPUT
           echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}" >> $GITHUB_OUTPUT
 
+      - name: Set up Docker Qemu
+        id: qemu
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -80,6 +84,7 @@ jobs:
           tags: ${{ steps.tags.outputs.result }}
           push: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64,linux/amd64
           build-args: |
             GIT_HASH=${{ github.sha }}
             GIT_VERSION=${{ steps.version.outputs.version }} 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,10 @@ jobs:
           echo "version_major=${GIT_VERSION_MAJOR}" >> $GITHUB_OUTPUT
           echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}" >> $GITHUB_OUTPUT
 
+      - name: Set up Docker Qemu
+        id: qemu
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -93,6 +97,7 @@ jobs:
           tags: ${{ steps.tags.outputs.result }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64,linux/amd64
           build-args: |
             GIT_HASH=${{ github.sha }}
             GIT_VERSION=${{ steps.version.outputs.version }} 


### PR DESCRIPTION
#### Motivation

We use a lot of ARM spot instances, which causes both ARM and x86 nodes to be used when argo-tasks is used. So by publishing a ARM container of argo-tasks we can use the existing ARM spot instances


#### Modification

Adds `arm64` as a docker build platform


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
