### PR TITLE
feat: lint imagery input target paths TDE-857

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ LINZ uses [Argo workflows](https://argoproj.github.io/workflows/) for running bu
 - [lds-fetch-layer](#lds-fetch-layer)
 - [create-manifest](#create-manifest)
 - [group](#group)
+- [lint](#lint)
 - [list](#list)
 - [pretty-print](#pretty-print)
 - [stac catalog](#stac-catalog)
@@ -36,6 +37,16 @@ Multiple layers can be fetched at the same time, fetch `51002` and `51000`:
 
 ```bash
 lds-fetch-layer  --target ./output 51002 51000
+```
+
+### `lint`
+
+Lint imagery s3 target paths
+
+#### Example
+
+```bash
+lint-inputs s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/
 ```
 
 ### `list`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Multiple layers can be fetched at the same time, fetch `51002` and `51000`:
 lds-fetch-layer  --target ./output 51002 51000
 ```
 
-### `lint`
+### `lint-inputs`
 
 Lint imagery s3 target paths
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ LINZ uses [Argo workflows](https://argoproj.github.io/workflows/) for running bu
 - [lds-fetch-layer](#lds-fetch-layer)
 - [create-manifest](#create-manifest)
 - [group](#group)
-- [lint](#lint)
+- [lint-inputs](#lint-inputs)
 - [list](#list)
 - [pretty-print](#pretty-print)
 - [stac catalog](#stac-catalog)

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,6 +7,7 @@ import { commandCreateManifest } from './create-manifest/create-manifest.js';
 import { commandPrettyPrint } from './format/pretty.print.js';
 import { commandGroup } from './group/group.js';
 import { commandLdsFetch } from './lds-cache/lds.cache.js';
+import { commandLintInputs } from './lint/lint.s3.paths.js';
 import { commandList } from './list/list.js';
 import { commandStacCatalog } from './stac-catalog/stac.catalog.js';
 import { commandStacGithubImport } from './stac-github-import/stac.github.import.js';
@@ -47,5 +48,6 @@ export const cmd = subcommands({
       },
     }),
     'pretty-print': commandPrettyPrint,
+    'lint-inputs': commandLintInputs,
   },
 });

--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { lintODRImageryPath } from '../lint.s3.paths.js';
+
+describe('lintODRImageryPaths', () => {
+  it('Should Fail - Incorrect Bucket Name', () => {
+    assert.throws(() => {
+      lintODRImageryPath('s3://n-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
+    }, Error);
+  });
+  it('Should Fail - Incorrect Region', () => {
+    assert.throws(() => {
+      lintODRImageryPath('s3://nz-imagery/hawkesbay/hawkes-bay_2012_0.075m/rgb/2193/');
+    }, Error);
+  });
+  it('Should Fail - Incorrect product', () => {
+    assert.throws(() => {
+      lintODRImageryPath('s3://nz-imagery/hawkes-bay/hawkes-bay_2012_0.075m/rgbi/2193/');
+    }, Error);
+  });
+  it('Should Fail - Incorrect Crs', () => {
+    assert.throws(() => {
+      lintODRImageryPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/219/');
+    }, Error);
+  });
+  it('Should Pass', () => {
+    assert.throws(() => {
+      lintODRImageryPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
+    }, Error);
+  });
+});

--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -9,6 +9,16 @@ describe('lintImageryPaths', () => {
       lintPath('s3://n-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
     }, Error);
   });
+  it('Should Fail - Missing key (Product)', () => {
+    assert.throws(() => {
+      lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/2193/');
+    }, Error);
+  });
+  it('Should Fail - Extra args', () => {
+    assert.throws(() => {
+      lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/2193/extra-args/');
+    }, Error);
+  });
   it('Should Pass', () => {
     assert.ok(() => {
       lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
@@ -17,29 +27,24 @@ describe('lintImageryPaths', () => {
 });
 
 describe('lintImageryPaths', () => {
-  it('Should Fail - Missing key', () => {
-    assert.throws(() => {
-      lintImageryPath(['nz-imagery', 'auckland', 'auckland_2012_0.075m', '2193', '']);
-    }, Error);
-  });
   it('Should Fail - Incorrect Region', () => {
     assert.throws(() => {
-      lintImageryPath(['nz-imagery', 'hawkesbay', 'hawkes-bay_2012_0.075m', 'rgb', '2193', '']);
+      lintImageryPath('hawkesbay', 'rgb', '2193');
     }, Error);
   });
   it('Should Fail - Incorrect product', () => {
     assert.throws(() => {
-      lintImageryPath(['nz-imagery', 'hawkes-bay', 'hawkes-bay_2012_0.075m', 'rgbi', '2193', '']);
+      lintImageryPath('hawkes-bay', 'rgbi', '2193');
     }, Error);
   });
   it('Should Fail - Incorrect Crs', () => {
     assert.throws(() => {
-      lintImageryPath(['nz-imagery', 'auckland', 'auckland_2012_0.075m', 'rgb', '219', '']);
+      lintImageryPath('auckland', 'rgb', '219');
     }, Error);
   });
   it('Should Pass', () => {
     assert.ok(() => {
-      lintImageryPath(['nz-imagery', 'auckland', 'auckland_2012_0.075m', 'rgb', '2193', '']);
+      lintImageryPath('auckland', 'rgb', '2193');
     });
   });
 });

--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { AdditionalKeyError, InvalidKeyError, MissingKeyError, lintImageryPath, lintPath } from '../lint.s3.paths.js';
+import { AdditionalKeyError, InvalidKeyError, lintImageryPath, lintPath, MissingKeyError } from '../lint.s3.paths.js';
 
 describe('lintImageryPaths', () => {
   it('Should Fail - Incorrect Bucket Name', () => {

--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -1,37 +1,45 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { lintODRImageryPath } from '../lint.s3.paths.js';
+import { lintImageryPath, lintPath } from '../lint.s3.paths.js';
 
-describe('lintODRImageryPaths', () => {
-  it('Should Fail - Missing key', () => {
-    assert.throws(() => {
-      lintODRImageryPath('s3://nz-imagery/auckland/auckland_2012_0.075m/2193/');
-    }, Error);
-  });
+describe('lintImageryPaths', () => {
   it('Should Fail - Incorrect Bucket Name', () => {
     assert.throws(() => {
-      lintODRImageryPath('s3://n-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
-    }, Error);
-  });
-  it('Should Fail - Incorrect Region', () => {
-    assert.throws(() => {
-      lintODRImageryPath('s3://nz-imagery/hawkesbay/hawkes-bay_2012_0.075m/rgb/2193/');
-    }, Error);
-  });
-  it('Should Fail - Incorrect product', () => {
-    assert.throws(() => {
-      lintODRImageryPath('s3://nz-imagery/hawkes-bay/hawkes-bay_2012_0.075m/rgbi/2193/');
-    }, Error);
-  });
-  it('Should Fail - Incorrect Crs', () => {
-    assert.throws(() => {
-      lintODRImageryPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/219/');
+      lintPath('s3://n-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
     }, Error);
   });
   it('Should Pass', () => {
     assert.ok(() => {
-      lintODRImageryPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
+      lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
+    });
+  });
+});
+
+describe('lintImageryPaths', () => {
+  it('Should Fail - Missing key', () => {
+    assert.throws(() => {
+      lintImageryPath(['nz-imagery', 'auckland', 'auckland_2012_0.075m', '2193', '']);
+    }, Error);
+  });
+  it('Should Fail - Incorrect Region', () => {
+    assert.throws(() => {
+      lintImageryPath(['nz-imagery', 'hawkesbay', 'hawkes-bay_2012_0.075m', 'rgb', '2193', '']);
+    }, Error);
+  });
+  it('Should Fail - Incorrect product', () => {
+    assert.throws(() => {
+      lintImageryPath(['nz-imagery', 'hawkes-bay', 'hawkes-bay_2012_0.075m', 'rgbi', '2193', '']);
+    }, Error);
+  });
+  it('Should Fail - Incorrect Crs', () => {
+    assert.throws(() => {
+      lintImageryPath(['nz-imagery', 'auckland', 'auckland_2012_0.075m', 'rgb', '219', '']);
+    }, Error);
+  });
+  it('Should Pass', () => {
+    assert.ok(() => {
+      lintImageryPath(['nz-imagery', 'auckland', 'auckland_2012_0.075m', 'rgb', '2193', '']);
     });
   });
 });

--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -1,23 +1,23 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { lintImageryPath, lintPath } from '../lint.s3.paths.js';
+import { AdditionalKeyError, InvalidKeyError, MissingKeyError, lintImageryPath, lintPath } from '../lint.s3.paths.js';
 
 describe('lintImageryPaths', () => {
   it('Should Fail - Incorrect Bucket Name', () => {
     assert.throws(() => {
       lintPath('s3://n-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
-    }, Error);
+    }, InvalidKeyError);
   });
   it('Should Fail - Missing key (Product)', () => {
     assert.throws(() => {
       lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/2193/');
-    }, Error);
+    }, MissingKeyError);
   });
   it('Should Fail - Extra args', () => {
     assert.throws(() => {
-      lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/2193/extra-args/');
-    }, Error);
+      lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/extra-args/');
+    }, AdditionalKeyError);
   });
   it('Should Pass', () => {
     assert.ok(() => {
@@ -30,17 +30,17 @@ describe('lintImageryPaths', () => {
   it('Should Fail - Incorrect Region', () => {
     assert.throws(() => {
       lintImageryPath('hawkesbay', 'rgb', '2193');
-    }, Error);
+    }, InvalidKeyError);
   });
   it('Should Fail - Incorrect product', () => {
     assert.throws(() => {
       lintImageryPath('hawkes-bay', 'rgbi', '2193');
-    }, Error);
+    }, InvalidKeyError);
   });
   it('Should Fail - Incorrect Crs', () => {
     assert.throws(() => {
       lintImageryPath('auckland', 'rgb', '219');
-    }, Error);
+    }, InvalidKeyError);
   });
   it('Should Pass', () => {
     assert.ok(() => {

--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -12,12 +12,12 @@ describe('lintImageryPaths', () => {
   it('Should Fail - Missing key (Product)', () => {
     assert.throws(() => {
       lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/2193/');
-    }, Error('Missing Key in Path: s3://nz-imagery/auckland/auckland_2012_0.075m/2193/'));
+    }, Error('Missing key in Path: /auckland/auckland_2012_0.075m/2193/'));
   });
   it('Should Fail - Extra args', () => {
     assert.throws(() => {
       lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/extra-args/');
-    }, Error('Additional arguments in path: s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/extra-args/'));
+    }, Error('Too many keys in Path: /auckland/auckland_2012_0.075m/rgb/2193/extra-args/'));
   });
   it('Should Pass', () => {
     assert.ok(() => {
@@ -29,22 +29,22 @@ describe('lintImageryPaths', () => {
 describe('lintImageryPaths', () => {
   it('Should Fail - Incorrect Region', () => {
     assert.throws(() => {
-      lintImageryPath('hawkesbay', 'rgb', '2193');
+      lintImageryPath('/hawkesbay/hawkes-bay_2018_0-75m/rgb/2193/');
     }, Error('region not in region list: hawkesbay'));
   });
   it('Should Fail - Incorrect product', () => {
     assert.throws(() => {
-      lintImageryPath('hawkes-bay', 'rgbi', '2193');
+      lintImageryPath('/hawkes-bay/hawkes-bay_2018_0-75m/rgbi/2193/');
     }, Error('product not in product list: rgbi'));
   });
   it('Should Fail - Incorrect Crs', () => {
     assert.throws(() => {
-      lintImageryPath('auckland', 'rgb', '219');
+      lintImageryPath('/auckland/auckland_2020_0-2m/rgb/219/');
     }, Error('crs not in crs list: 219'));
   });
   it('Should Pass', () => {
     assert.ok(() => {
-      lintImageryPath('auckland', 'rgb', '2193');
+      lintImageryPath('/auckland/auckland_2020_0-2m/rgb/2193/');
     });
   });
 });

--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -30,8 +30,8 @@ describe('lintODRImageryPaths', () => {
     }, Error);
   });
   it('Should Pass', () => {
-    assert.throws(() => {
+    assert.ok(() => {
       lintODRImageryPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
-    }, Error);
+    });
   });
 });

--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -4,6 +4,11 @@ import { describe, it } from 'node:test';
 import { lintODRImageryPath } from '../lint.s3.paths.js';
 
 describe('lintODRImageryPaths', () => {
+  it('Should Fail - Missing key', () => {
+    assert.throws(() => {
+      lintODRImageryPath('s3://nz-imagery/auckland/auckland_2012_0.075m/2193/');
+    }, Error);
+  });
   it('Should Fail - Incorrect Bucket Name', () => {
     assert.throws(() => {
       lintODRImageryPath('s3://n-imagery/auckland/auckland_2012_0.075m/rgb/2193/');

--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -1,23 +1,23 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { AdditionalKeyError, InvalidKeyError, lintImageryPath, lintPath, MissingKeyError } from '../lint.s3.paths.js';
+import { lintImageryPath, lintPath } from '../lint.s3.paths.js';
 
 describe('lintImageryPaths', () => {
   it('Should Fail - Incorrect Bucket Name', () => {
     assert.throws(() => {
       lintPath('s3://n-imagery/auckland/auckland_2012_0.075m/rgb/2193/');
-    }, InvalidKeyError);
+    }, Error('bucket not in bucket list: n-imagery'));
   });
   it('Should Fail - Missing key (Product)', () => {
     assert.throws(() => {
       lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/2193/');
-    }, MissingKeyError);
+    }, Error('Missing Key in Path: s3://nz-imagery/auckland/auckland_2012_0.075m/2193/'));
   });
   it('Should Fail - Extra args', () => {
     assert.throws(() => {
       lintPath('s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/extra-args/');
-    }, AdditionalKeyError);
+    }, Error('Additional arguments in path: s3://nz-imagery/auckland/auckland_2012_0.075m/rgb/2193/extra-args/'));
   });
   it('Should Pass', () => {
     assert.ok(() => {
@@ -30,17 +30,17 @@ describe('lintImageryPaths', () => {
   it('Should Fail - Incorrect Region', () => {
     assert.throws(() => {
       lintImageryPath('hawkesbay', 'rgb', '2193');
-    }, InvalidKeyError);
+    }, Error('region not in region list: hawkesbay'));
   });
   it('Should Fail - Incorrect product', () => {
     assert.throws(() => {
       lintImageryPath('hawkes-bay', 'rgbi', '2193');
-    }, InvalidKeyError);
+    }, Error('product not in product list: rgbi'));
   });
   it('Should Fail - Incorrect Crs', () => {
     assert.throws(() => {
       lintImageryPath('auckland', 'rgb', '219');
-    }, InvalidKeyError);
+    }, Error('crs not in crs list: 219'));
   });
   it('Should Pass', () => {
     assert.ok(() => {

--- a/src/commands/lint/lint.constants.ts
+++ b/src/commands/lint/lint.constants.ts
@@ -17,6 +17,8 @@ export const regions = [
   'southland',
 ];
 
+export const imageryBucketNames = ['linz-imagery', 'nz-imagery'];
+
 export const imageryProducts = ['rgb'];
 
 export const imageryCrs = ['2193'];

--- a/src/commands/lint/lint.constants.ts
+++ b/src/commands/lint/lint.constants.ts
@@ -1,0 +1,22 @@
+export const regions = [
+    'northland',
+    'auckland',
+    'waikato',
+    'bay-of-plenty',
+    'gisborne',
+    'hawkes-bay',
+    'taranaki',
+    'manawatu-whanganui',
+    'wellington',
+    'tasman',
+    'nelson',
+    'marlborough',
+    'west-coast',
+    'canterbury',
+    'otago',
+    'southland',
+  ];
+
+  export const imageryProducts = ['rgb']
+
+  export const imageryCrs = ['2193']

--- a/src/commands/lint/lint.constants.ts
+++ b/src/commands/lint/lint.constants.ts
@@ -1,3 +1,5 @@
+import { EpsgCode } from '@basemaps/geo';
+
 export const regions = [
   'northland',
   'auckland',
@@ -21,4 +23,4 @@ export const imageryBucketNames = ['linz-imagery', 'nz-imagery'];
 
 export const imageryProducts = ['rgb'];
 
-export const imageryCrs = ['2193'];
+export const imageryCrs = [EpsgCode.Nztm2000];

--- a/src/commands/lint/lint.constants.ts
+++ b/src/commands/lint/lint.constants.ts
@@ -1,22 +1,22 @@
 export const regions = [
-    'northland',
-    'auckland',
-    'waikato',
-    'bay-of-plenty',
-    'gisborne',
-    'hawkes-bay',
-    'taranaki',
-    'manawatu-whanganui',
-    'wellington',
-    'tasman',
-    'nelson',
-    'marlborough',
-    'west-coast',
-    'canterbury',
-    'otago',
-    'southland',
-  ];
+  'northland',
+  'auckland',
+  'waikato',
+  'bay-of-plenty',
+  'gisborne',
+  'hawkes-bay',
+  'taranaki',
+  'manawatu-whanganui',
+  'wellington',
+  'tasman',
+  'nelson',
+  'marlborough',
+  'west-coast',
+  'canterbury',
+  'otago',
+  'southland',
+];
 
-  export const imageryProducts = ['rgb']
+export const imageryProducts = ['rgb'];
 
-  export const imageryCrs = ['2193']
+export const imageryCrs = ['2193'];

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -44,7 +44,7 @@ export function lintPath(path: string): void {
 }
 
 export function lintImageryPath(pathName: string): void {
-  const [_, region, dataset, product, crs] = pathName.split('/', 5);
+  const [, region, dataset, product, crs] = pathName.split('/', 5);
 
   if (region === undefined || dataset === undefined || product === undefined || crs === undefined) {
     throw new Error(`Missing Key in Path: ${pathName}`);

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -3,7 +3,7 @@ import { command, positional, string } from 'cmd-ts';
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
 import { config, registerCli, verbose } from '../common.js';
-import { imageryCrs, imageryProducts, regions } from './lint.constants.js';
+import { imageryBucketNames, imageryCrs, imageryProducts, regions } from './lint.constants.js';
 
 export const commandLintInputs = command({
   name: 'lint-inputs',
@@ -22,30 +22,41 @@ export const commandLintInputs = command({
   async handler(args) {
     registerCli(this, args);
     const startTime = performance.now();
+
     logger.info('LintInputs:Start');
     if (!args.path) {
       throw new Error('No path Provided');
     }
     logger.info({ target: args.path }, 'LintInputs:Info');
-    lintODRImageryPath(args.path);
+    lintPath(args.path);
     logger.info({ duration: performance.now() - startTime }, 'LintInputs:Done');
   },
 });
 
-export function lintODRImageryPath(path: string): void {
+export function lintPath(path: string): void {
   const pathArray: string[] = path.replace('s3://', '').split('/');
   const bucket: string | undefined = pathArray[0];
+
+  if (bucket == null) {
+    throw new Error(`No Bucket Specified: ${path}`);
+  }
+
+  if (imageryBucketNames.includes(bucket)) {
+    lintImageryPath(pathArray);
+  } else {
+    throw new Error(`Bucket not bucket list: ${bucket}`);
+  }
+}
+
+export function lintImageryPath(pathArray: string[]): void {
   const region: string | undefined = pathArray[1];
   const dataset: string | undefined = pathArray[2];
   const product: string | undefined = pathArray[3];
   const crs: string | undefined = pathArray[4];
 
   // lint target path
-  if (bucket == null || region == null || dataset == null || product == null || crs == null) {
-    throw new Error(`Missing key from path: ${path}`);
-  }
-  if (bucket !== 'nz-imagery') {
-    throw new Error(`Incorrect Bucket: ${bucket}`);
+  if (region == null || dataset == null || product == null || crs == null) {
+    throw new Error(`Missing key from path: s3://${pathArray.join('/')}`);
   }
   if (!regions.includes(region)) {
     throw new Error(`Provided region not in region list: ${region}`);

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -42,6 +42,9 @@ export function lintPath(path: string): void {
   if (region == null || dataset == null || product == null || crs == null) {
     throw new Error(`Missing key from path: ${path}`);
   }
+  if (!path.endsWith(`${crs}/`)) {
+    throw new Error(`Additional arguments in path, please remove: ${path.split(`${crs}/`)[1]}`);
+  }
   if (imageryBucketNames.includes(bucket)) {
     lintImageryPath(region, product, crs);
   } else {

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -34,26 +34,27 @@ export const commandLintInputs = command({
 });
 
 export function lintPath(path: string): void {
-  const [bucket, region, dataset, product, crs] = path.replace('s3://', '').split('/', 5);
+  const url = new URL(path);
 
-  if (bucket == null || region == null || dataset == null || product == null || crs == null) {
-    throw new Error(`Missing Key in Path: ${path}`);
-  }
-  if (bucket === '' || region === '' || dataset === '' || product === '' || crs === '') {
-    throw new Error(`Missing Key in Path: ${path}`);
-  }
-  console.log(crs);
-  if (!path.endsWith(`${crs}/`)) {
-    throw new Error(`Additional arguments in path: ${path}`);
-  }
-  if (imageryBucketNames.includes(bucket)) {
-    lintImageryPath(region, product, crs);
+  if (imageryBucketNames.includes(url.hostname)) {
+    lintImageryPath(url.pathname);
   } else {
-    throw new Error(`bucket not in bucket list: ${bucket}`);
+    throw new Error(`bucket not in bucket list: ${url.hostname}`);
   }
 }
 
-export function lintImageryPath(region: string, product: string, crs: string): void {
+export function lintImageryPath(pathName: string): void {
+  const [_, region, dataset, product, crs] = pathName.split('/', 5);
+
+  if (region === undefined || dataset === undefined || product === undefined || crs === undefined) {
+    throw new Error(`Missing Key in Path: ${pathName}`);
+  }
+  if (pathName.split('/').length < 6) {
+    throw new Error(`Missing key in Path: ${pathName}`);
+  }
+  if (pathName.split('/').length > 6) {
+    throw new Error(`Too many keys in Path: ${pathName}`);
+  }
   if (!regions.includes(region)) {
     throw new Error(`region not in region list: ${region}`);
   }

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -44,7 +44,7 @@ export function lintODRImageryPath(path: string): void {
   if (bucket == null || region == null || dataset == null || product == null || crs == null) {
     throw new Error(`Missing key from path: ${path}`);
   }
-  if (bucket != 'nz-imagery') {
+  if (bucket !== 'nz-imagery') {
     throw new Error(`Incorrect Bucket: ${bucket}`);
   }
   if (!regions.includes(region)) {

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -1,0 +1,58 @@
+import { command, positional, string } from 'cmd-ts';
+
+import { CliInfo } from '../../cli.info.js';
+import { logger } from '../../log.js';
+import { config, registerCli, verbose } from '../common.js';
+import { imageryCrs, imageryProducts, regions } from './lint.constants.js';
+
+export const commandLintInputs = command({
+  name: 'lint-inputs',
+  description: 'Pretty print JSON files',
+  version: CliInfo.version,
+  args: {
+    config,
+    verbose,
+    path: positional({
+      type: string,
+      displayName: 'path',
+      description: 'JSON file to load inputs from, must be a JSON Array',
+    }),
+  },
+
+  async handler(args) {
+    registerCli(this, args);
+    const startTime = performance.now();
+    logger.info('LintInputs:Start');
+    if (!args.path) {
+      throw new Error('No path Provided');
+    }
+    logger.info({ target: args.path }, 'LintInputs:Info');
+    lintODRImageryPath(args.path);
+    logger.info({ duration: performance.now() - startTime }, 'LintInputs:Done');
+  },
+});
+
+export function lintODRImageryPath(path: string): void {
+  const pathArray: string[] = path.replace('s3://', '').split('/');
+  const pathObj = {
+    bucket: pathArray[0],
+    region: pathArray[1],
+    dataset: pathArray[2],
+    product: pathArray[3],
+    crs: pathArray[4],
+  };
+
+  // lint target path
+  if (pathObj.bucket != null && pathObj.bucket != 'nz-imagery') {
+    throw new Error(`Incorrect Bucket: ${pathObj.bucket}`);
+  }
+  if (pathObj.region != null && !regions.includes(pathObj.region)) {
+    throw new Error(`Provided region not in region list: ${pathObj.region}`);
+  }
+  if (pathObj.product != null && !imageryProducts.includes(pathObj.product)) {
+    throw new Error(`Provided region not in imagery products list: ${pathObj.product}`);
+  }
+  if (pathObj.crs != null && !imageryCrs.includes(pathObj.crs)) {
+    throw new Error(`Provided crs not in imagery crs list: ${pathObj.crs}`);
+  }
+}

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -34,25 +34,26 @@ export const commandLintInputs = command({
 
 export function lintODRImageryPath(path: string): void {
   const pathArray: string[] = path.replace('s3://', '').split('/');
-  const pathObj = {
-    bucket: pathArray[0],
-    region: pathArray[1],
-    dataset: pathArray[2],
-    product: pathArray[3],
-    crs: pathArray[4],
-  };
+  const bucket: string | undefined = pathArray[0];
+  const region: string | undefined = pathArray[1];
+  const dataset: string | undefined = pathArray[2];
+  const product: string | undefined = pathArray[3];
+  const crs: string | undefined = pathArray[4];
 
   // lint target path
-  if (pathObj.bucket != null && pathObj.bucket != 'nz-imagery') {
-    throw new Error(`Incorrect Bucket: ${pathObj.bucket}`);
+  if (bucket == null || region == null || dataset == null || product == null || crs == null) {
+    throw new Error(`Missing key from path: ${path}`);
   }
-  if (pathObj.region != null && !regions.includes(pathObj.region)) {
-    throw new Error(`Provided region not in region list: ${pathObj.region}`);
+  if (bucket != 'nz-imagery') {
+    throw new Error(`Incorrect Bucket: ${bucket}`);
   }
-  if (pathObj.product != null && !imageryProducts.includes(pathObj.product)) {
-    throw new Error(`Provided region not in imagery products list: ${pathObj.product}`);
+  if (!regions.includes(region)) {
+    throw new Error(`Provided region not in region list: ${region}`);
   }
-  if (pathObj.crs != null && !imageryCrs.includes(pathObj.crs)) {
-    throw new Error(`Provided crs not in imagery crs list: ${pathObj.crs}`);
+  if (!imageryProducts.includes(product)) {
+    throw new Error(`Provided region not in imagery products list: ${product}`);
+  }
+  if (!imageryCrs.includes(crs)) {
+    throw new Error(`Provided crs not in imagery crs list: ${crs}`);
   }
 }

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -5,27 +5,6 @@ import { logger } from '../../log.js';
 import { config, registerCli, verbose } from '../common.js';
 import { imageryBucketNames, imageryCrs, imageryProducts, regions } from './lint.constants.js';
 
-export class MissingKeyError extends Error {
-  constructor(path: string) {
-    super(`Missing Key in Path: ${path}`);
-    this.name = 'MissingKeyError';
-  }
-}
-
-export class AdditionalKeyError extends Error {
-  constructor(path: string) {
-    super(`Additional arguments in path: ${path}`);
-    this.name = 'AdditionalKeyError';
-  }
-}
-
-export class InvalidKeyError extends Error {
-  constructor(type: string, value: string) {
-    super(`${type} not in ${type} list: ${value}`);
-    this.name = 'InvalidKeyError';
-  }
-}
-
 export const commandLintInputs = command({
   name: 'lint-inputs',
   description: 'Pretty print JSON files',
@@ -58,30 +37,30 @@ export function lintPath(path: string): void {
   const [bucket, region, dataset, product, crs] = path.replace('s3://', '').split('/', 5);
 
   if (bucket == null || region == null || dataset == null || product == null || crs == null) {
-    throw new MissingKeyError(path);
+    throw new Error(`Missing Key in Path: ${path}`);
   }
   if (bucket === '' || region === '' || dataset === '' || product === '' || crs === '') {
-    throw new MissingKeyError(path);
+    throw new Error(`Missing Key in Path: ${path}`);
   }
   console.log(crs);
   if (!path.endsWith(`${crs}/`)) {
-    throw new AdditionalKeyError(path);
+    throw new Error(`Additional arguments in path: ${path}`);
   }
   if (imageryBucketNames.includes(bucket)) {
     lintImageryPath(region, product, crs);
   } else {
-    throw new InvalidKeyError('Bucket', bucket);
+    throw new Error(`bucket not in bucket list: ${bucket}`);
   }
 }
 
 export function lintImageryPath(region: string, product: string, crs: string): void {
   if (!regions.includes(region)) {
-    throw new InvalidKeyError('region', region);
+    throw new Error(`region not in region list: ${region}`);
   }
   if (!imageryProducts.includes(product)) {
-    throw new InvalidKeyError('product', product);
+    throw new Error(`product not in product list: ${product}`);
   }
   if (!imageryCrs.includes(crs)) {
-    throw new InvalidKeyError('crs', crs);
+    throw new Error(`crs not in crs list: ${crs}`);
   }
 }

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -34,30 +34,22 @@ export const commandLintInputs = command({
 });
 
 export function lintPath(path: string): void {
-  const pathArray: string[] = path.replace('s3://', '').split('/');
-  const bucket: string | undefined = pathArray[0];
+  const [bucket, region, dataset, product, crs] = path.replace('s3://', '').split('/', 5);
 
   if (bucket == null) {
     throw new Error(`No Bucket Specified: ${path}`);
   }
-
+  if (region == null || dataset == null || product == null || crs == null) {
+    throw new Error(`Missing key from path: ${path}`);
+  }
   if (imageryBucketNames.includes(bucket)) {
-    lintImageryPath(pathArray);
+    lintImageryPath(region, product, crs);
   } else {
     throw new Error(`Bucket not bucket list: ${bucket}`);
   }
 }
 
-export function lintImageryPath(pathArray: string[]): void {
-  const region: string | undefined = pathArray[1];
-  const dataset: string | undefined = pathArray[2];
-  const product: string | undefined = pathArray[3];
-  const crs: string | undefined = pathArray[4];
-
-  // lint target path
-  if (region == null || dataset == null || product == null || crs == null) {
-    throw new Error(`Missing key from path: s3://${pathArray.join('/')}`);
-  }
+export function lintImageryPath(region: string, product: string, crs: string): void {
   if (!regions.includes(region)) {
     throw new Error(`Provided region not in region list: ${region}`);
   }

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -61,7 +61,7 @@ export function lintImageryPath(pathName: string): void {
   if (!imageryProducts.includes(product)) {
     throw new Error(`product not in product list: ${product}`);
   }
-  if (!imageryCrs.includes(crs)) {
+  if (!imageryCrs.includes(Number(crs))) {
     throw new Error(`crs not in crs list: ${crs}`);
   }
 }


### PR DESCRIPTION
#### Motivation

in order to be sure that workflow input public taraget paths follow conventions by linting workflow inputs where possible.

#### Modification

Adding lint-paths step to argo-tasks which will be used in `pubish-odr` and can also be added to `publish-copy`

Currently just the publish paths are linted (linz-imagery & nz-imagery) - this was based on the ticket description but more can be added if required. 
The dataset section of the s3 path is currently not linted as this is too variable to check?

(this change will be used in a topo-workflow PR currently WIP)

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
