### PR TITLE
fix(basemaps): create-mapsheet config arg conflicts with role config arg

### DIFF
--- a/src/commands/basemaps-mapsheet/create-mapsheet.ts
+++ b/src/commands/basemaps-mapsheet/create-mapsheet.ts
@@ -21,9 +21,9 @@ export const CommandCreateMapSheetArgs = {
     long: 'path',
     description: 'Path of flatgeobuf, this can be both a local path or s3 location',
   }),
-  config: option({
+  bmConfig: option({
     type: string,
-    long: 'config',
+    long: 'bm-config',
     description: 'Path of basemaps config json, this can be both a local path or s3 location',
   }),
   output: option({
@@ -51,7 +51,7 @@ export const basemapsCreateMapSheet = command({
   async handler(args) {
     registerCli(this, args);
     const path = args.path;
-    const config = args.config;
+    const config = args.bmConfig;
     const outputPath = args.output;
 
     const include = args.include ? new RegExp(args.include.toLowerCase(), 'i') : undefined;


### PR DESCRIPTION
#### Motivation
We using the `--config` for the aws role config as default arguments in [argo tasks](https://github.com/linz/argo-tasks/blob/a56088232b91e4514e384f714656ea41dbefe695/src/fs.register.ts#L21). This is conflicts with the basemaps config argument. 

#### Modification
Rename the basemaps config argument to `bm-config`

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
