### PR TITLE
ci: add nonprod and prod environments BM-923

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,11 +31,14 @@ jobs:
 
     # On push to master when it is not a release!
     if: ${{ github.ref == 'refs/heads/master' && !startsWith(github.event.head_commit.message, 'release:') }}
+
     needs: ['build']
+
     permissions:
       id-token: write
       contents: read
       packages: write
+
     env:
       AWS_CI_ROLE: ${{ secrets.AWS_CI_ROLE }}
 
@@ -87,6 +90,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CI_ROLE }}
 
       - name: Login to Amazon ECR
+        if: ${{env.AWS_CI_ROLE != ''}}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -115,6 +115,7 @@ jobs:
         with:
           context: .
           tags: ${{ steps.tags.outputs.result }}
+          push: true
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64,linux/amd64
           build-args: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,12 +5,42 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    steps:
+      - uses: linz/action-typescript@v3
+
+      # Only build containers on branches otherwise container builds are duplicated deploy-nonprod-containers 
+      - name: Set up Docker Buildx
+        if: ${{ github.ref != 'refs/heads/master' }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build container
+        if: ${{ github.ref != 'refs/heads/master' }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          build-args: |
+            GIT_HASH=${{ github.sha }}
+            GITHUB_RUN_ID=${{ github.run_id}}
+
+  deploy-nonprod-containers:
+    runs-on: ubuntu-latest
+
+    concurrency: deploy-dev-${{ github.ref }}
+
+    # On push to master when it is not a release!
+    if: ${{ github.ref == 'refs/heads/master' && !startsWith(github.event.head_commit.message, 'release:') }}
+    needs: ['build']
     permissions:
       id-token: write
       contents: read
       packages: write
     env:
       AWS_CI_ROLE: ${{ secrets.AWS_CI_ROLE }}
+
+    environment:
+      name: nonprod
 
     steps:
       - uses: linz/action-typescript@v3
@@ -42,7 +72,6 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
 
       - name: Login to GitHub Container Registry
-        if: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -50,7 +79,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
-        if: ${{env.AWS_CI_ROLE != '' && (github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
+        if: ${{env.AWS_CI_ROLE != ''}}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ap-southeast-2
@@ -58,7 +87,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CI_ROLE }}
 
       - name: Login to Amazon ECR
-        if: ${{env.AWS_CI_ROLE != '' && (github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
@@ -67,13 +95,14 @@ jobs:
         uses: actions/github-script@v6
         with:
           result-encoding: string
-          script: const tags = [];
+          script: |
+            const tags = [];
             tags.push('ghcr.io/${{ github.repository }}:latest');
             tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}');
 
             if ("${{ steps.login-ecr.outputs.registry }}") {
-            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:latest');
-            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
+              tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:latest');
+              tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
             }
             return tags.join(', ')
 
@@ -82,7 +111,6 @@ jobs:
         with:
           context: .
           tags: ${{ steps.tags.outputs.result }}
-          push: ${{(github.ref == 'refs/heads/master') && !(startsWith(github.event.head_commit.message, 'release:'))}}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64,linux/amd64
           build-args: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,10 @@ jobs:
   publish-release:
     needs: release-please
     runs-on: ubuntu-latest
+
+    environment:
+      name: prod
+
     permissions:
       id-token: write
       contents: read
@@ -76,17 +80,18 @@ jobs:
         uses: actions/github-script@v6
         with:
           result-encoding: string
-          script: const tags = [];
+          script: |
+            const tags = [];
             tags.push('ghcr.io/${{ github.repository }}:latest');
             tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version_major }}');
             tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version_major_minor }}');
             tags.push('ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}');
 
             if ("${{ steps.login-ecr.outputs.registry }}") {
-            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:latest');
-            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version_major }}');
-            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version_major_minor }}');
-            tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
+              tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:latest');
+              tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version_major }}');
+              tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version_major_minor }}');
+              tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
             }
             return tags.join(', ')
 


### PR DESCRIPTION
#### Motivation

Github deployment environments let us view what has been deployed where and is very helpful!

#### Modification

Add a `nonprod` and `prod` enviroment
Split the nonprod deployment to only on pushes to master

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
