### PR TITLE
feat: lint resolution TDE-938

### DIFF
--- a/src/commands/lint/__test__/lint.test.ts
+++ b/src/commands/lint/__test__/lint.test.ts
@@ -29,22 +29,27 @@ describe('lintImageryPaths', () => {
 describe('lintImageryPaths', () => {
   it('Should Fail - Incorrect Region', () => {
     assert.throws(() => {
-      lintImageryPath('/hawkesbay/hawkes-bay_2018_0-75m/rgb/2193/');
+      lintImageryPath('/hawkesbay/hawkes-bay_2018_0.75m/rgb/2193/');
     }, Error('region not in region list: hawkesbay'));
   });
   it('Should Fail - Incorrect product', () => {
     assert.throws(() => {
-      lintImageryPath('/hawkes-bay/hawkes-bay_2018_0-75m/rgbi/2193/');
+      lintImageryPath('/hawkes-bay/hawkes-bay_2018_0.75m/rgbi/2193/');
     }, Error('product not in product list: rgbi'));
   });
   it('Should Fail - Incorrect Crs', () => {
     assert.throws(() => {
-      lintImageryPath('/auckland/auckland_2020_0-2m/rgb/219/');
+      lintImageryPath('/auckland/auckland_2020_0.2m/rgb/219/');
     }, Error('crs not in crs list: 219'));
+  });
+  it('Should Fail - Trailing 0', () => {
+    assert.throws(() => {
+      lintImageryPath('/auckland/auckland_2020_0.20m/rgb/2193/');
+    }, Error('Trailing 0 in resolution of dataset name: auckland_2020_0.20m'));
   });
   it('Should Pass', () => {
     assert.ok(() => {
-      lintImageryPath('/auckland/auckland_2020_0-2m/rgb/2193/');
+      lintImageryPath('/auckland/auckland_2020_0.2m/rgb/2193/');
     });
   });
 });

--- a/src/commands/lint/lint.s3.paths.ts
+++ b/src/commands/lint/lint.s3.paths.ts
@@ -64,4 +64,8 @@ export function lintImageryPath(pathName: string): void {
   if (!imageryCrs.includes(Number(crs))) {
     throw new Error(`crs not in crs list: ${crs}`);
   }
+  const resolution = dataset.split('_').pop()?.replace('m', '');
+  if (resolution?.endsWith('0')) {
+    throw new Error(`Trailing 0 in resolution of dataset name: ${dataset}`);
+  }
 }


### PR DESCRIPTION
#### Motivation

ensure that the resolution of the dataset name in the target key doesn't have a trailing 0.
For example:
0.3m not 0.30m 
(This is just for naming conventions and is written manually).

#### Modification

resolution check added to `lint-inputs` command

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated - not required
- [x] Issue linked in Title
