### PR TITLE
fix: GitHub PAT for Argo Workflows Pull Requests TDE-940

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,8 @@ Format and push a STAC collection.json file to a GitHub repository. Used by the 
 
 #### Example
 
-Environment variables:
-GIT_AUTHOR_NAME="Example User"
-GIT_AUTHOR_EMAIL="<example@example.com>"
+Environment variable:
+GITHUB_API_TOKEN="pat_token_string"
 
 ```bash
 stac github-import --source s3://path/to/collection/ --target s3://linz-imagery/path/to/dataset/ --repo-name "linz/imagery-test)" (`--repo-name` is optional and defaults to linz/imagery).

--- a/README.md
+++ b/README.md
@@ -196,9 +196,6 @@ Format and push a STAC collection.json file to a GitHub repository. Used by the 
 
 #### Example
 
-Environment variable:
-GITHUB_API_TOKEN="pat_token_string"
-
 ```bash
 stac github-import --source s3://path/to/collection/ --target s3://linz-imagery/path/to/dataset/ --repo-name "linz/imagery-test)" (`--repo-name` is optional and defaults to linz/imagery).
 ```

--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -9,8 +9,8 @@ import { fsa } from '@chunkd/fs';
 
 import { logger } from '../../log.js';
 import { DEFAULT_PRETTIER_FORMAT } from '../../utils/config.js';
-import { prettyPrint } from '../format/pretty.print.js';
 import { createPR, GithubApi } from '../../utils/github.js';
+import { prettyPrint } from '../format/pretty.print.js';
 
 export enum Category {
   Urban = 'Urban Aerial Photos',

--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -10,7 +10,7 @@ import { fsa } from '@chunkd/fs';
 import { logger } from '../../log.js';
 import { DEFAULT_PRETTIER_FORMAT } from '../../utils/config.js';
 import { prettyPrint } from '../format/pretty.print.js';
-import { createPR, GithubApi } from './github.js';
+import { createPR, GithubApi } from '../../utils/github.js';
 
 export enum Category {
   Urban = 'Urban Aerial Photos',

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -5,7 +5,7 @@ import * as st from 'stac-ts';
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
 import { DEFAULT_PRETTIER_FORMAT } from '../../utils/config.js';
-import { createPR, GithubApi } from '../basemaps-github/github.js';
+import { createPR, GithubApi } from '../../utils/github.js';
 import { config, registerCli, verbose } from '../common.js';
 import { prettyPrint } from '../format/pretty.print.js';
 

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -38,7 +38,7 @@ export const commandStacGithubImport = command({
       type: string,
       long: 'repo-name',
       description: 'Repository name either linz/imagery or linz/elevation',
-      defaultValue: () => 'linz/imagery-test',
+      defaultValue: () => 'linz/imagery',
       defaultValueIsSerializable: true,
     }),
   },

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -38,7 +38,7 @@ export const commandStacGithubImport = command({
       type: string,
       long: 'repo-name',
       description: 'Repository name either linz/imagery or linz/elevation',
-      defaultValue: () => 'linz/imagery',
+      defaultValue: () => 'linz/imagery-test',
       defaultValueIsSerializable: true,
     }),
   },

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -53,6 +53,7 @@ export const commandStacGithubImport = command({
     const catalogPath = fsa.joinAll('template', 'catalog.json');
     const catalog = await gh.getContent(catalogPath);
     const catalogJson = JSON.parse(catalog) as st.StacCatalog;
+
     // Catalog template should have a absolute link to itself
     const selfLink = catalogJson.links.find((f) => f.rel === 'self');
     if (selfLink == null) throw new Error('unable to find self link in catalog');
@@ -61,9 +62,9 @@ export const commandStacGithubImport = command({
 
     const sourceCollection = new URL('collection.json', args.source);
     const targetCollection = new URL('collection.json', args.target);
+    const targetCollectionPath = fsa.joinAll('stac', targetCollection.pathname);
 
     const collection = await fsa.readJson<st.StacCollection>(sourceCollection.href);
-    const collectionPath = fsa.joinAll('stac', targetCollection.pathname);
 
     const rootLink = collection.links.find((f) => f.rel === 'root');
     if (rootLink) {
@@ -79,7 +80,7 @@ export const commandStacGithubImport = command({
     // commit and pull request title: "feat: import Manawatū-Whanganui 0.4m Rural Aerial Photos (2010-2011)"
     const title = `feat: import ${collection.title}`;
     const collectionFileContent = await prettyPrint(JSON.stringify(collection), DEFAULT_PRETTIER_FORMAT);
-    const collectionFile = { path: collectionPath, content: collectionFileContent };
+    const collectionFile = { path: targetCollectionPath, content: collectionFileContent };
     logger.info({ commit: `feat: import ${collection.title}`, branch: `feat/bot-${collection.id}` }, 'Git:Commit');
     // create pull request
     await createPR(gh, branch, title, [collectionFile]);

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -2,7 +2,7 @@ import { Octokit } from '@octokit/core';
 import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods';
 import { Api } from '@octokit/plugin-rest-endpoint-methods/dist-types/types.js';
 
-import { logger } from '../../log.js';
+import { logger } from '../log.js';
 
 export interface Job {
   imagery: string;

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -205,7 +205,7 @@ export async function createPR(gh: GithubApi, branch: string, title: string, fil
   const commitSha = await gh.createCommit(blobs, title, sha);
 
   // git push
-  logger.info({ branch }, 'GitHub: Push commit to Brach');
+  logger.info({ branch }, 'GitHub: Push commit to Branch');
   await gh.updateBranch(branch, commitSha);
 
   // git pr create


### PR DESCRIPTION
#### Motivation

To be consistent with Basemaps and so bulk processing for imagery and elevation is more reliable.

#### Modification

Move imagery and elevation GitHub Pull Requests from secrets to a PAT. Use existing Basemaps code, moving the core function into `utils` for common use.

#### Checklist

_If not applicable, provide explanation of why._

Tests still run successfully.

- [ ] Tests updated
- [X] Docs updated
- [X] Issue linked in Title
