### PR TITLE
fix: specify bot email address in Pull Requests TDE-983

### DIFF
--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -43,6 +43,7 @@ export function parseCategory(category: string): Category {
   else return Category.Other;
 }
 
+const botEmail = 'basemaps@linz.govt.nz';
 const ConfigPrettierFormat = Object.assign({}, DEFAULT_PRETTIER_FORMAT, { printWidth: 200 });
 
 export class MakeCogGithub {
@@ -85,7 +86,7 @@ export class MakeCogGithub {
       const tileSetPath = fsa.joinAll('config', 'tileset', region, `${layer.name}.json`);
       const file = { path: tileSetPath, content };
       // Github create pull request
-      await createPR(gh, branch, title, [file]);
+      await createPR(gh, branch, title, botEmail, [file]);
     } else {
       // Prepare new aerial tileset config
       const tileSetPath = fsa.joinAll('config', 'tileset', `${filename}.json`);
@@ -98,7 +99,7 @@ export class MakeCogGithub {
       const content = await prettyPrint(JSON.stringify(newTileSet, null, 2), ConfigPrettierFormat);
       const file = { path: tileSetPath, content };
       // Github create pull request
-      await createPR(gh, branch, title, [file]);
+      await createPR(gh, branch, title, botEmail, [file]);
     }
   }
 
@@ -187,7 +188,7 @@ export class MakeCogGithub {
     const content = await prettyPrint(JSON.stringify(newTileSet, null, 2), ConfigPrettierFormat);
     const file = { path: tileSetPath, content };
     // Github create pull request
-    await createPR(gh, branch, title, [file]);
+    await createPR(gh, branch, title, botEmail, [file]);
   }
 
   /**

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -47,14 +47,14 @@ export const commandStacGithubImport = command({
     registerCli(this, args);
 
     const gh = new GithubApi(args.repoName);
-    const validRepos = ['linz/elevation', 'linz/imagery'];
-    let botEmail: string;
 
-    if (validRepos.includes(args.repoName)) {
-      botEmail = `${args.repoName.split('/')[1]}@linz.govt.nz`;
-    } else {
-      throw new Error(`${args.repoName} is not a valid GitHub repository`);
-    }
+    const BotEmails: Record<string, string> = {
+      'linz/elevation': 'elevation@linz.govt.nz',
+      'linz/imagery': 'imagery@linz.govt.nz',
+    };
+
+    const botEmail = BotEmails[args.repoName];
+    if (botEmail == null) throw new Error(`${args.repoName} is not a valid GitHub repository`);
 
     // Load information from the template inside the repo
     logger.info({ template: fsa.joinAll('template', 'catalog.json') }, 'Stac:ReadTemplate');

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -52,8 +52,7 @@ export const commandStacGithubImport = command({
 
     if (validRepos.includes(args.repoName)) {
       botEmail = `${args.repoName.split('/')[1]}@linz.govt.nz`;
-    }
-    else {
+    } else {
       throw new Error(`${args.repoName} is not a valid GitHub repository`);
     }
 

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -47,6 +47,15 @@ export const commandStacGithubImport = command({
     registerCli(this, args);
 
     const gh = new GithubApi(args.repoName);
+    const validRepos = ['linz/elevation', 'linz/imagery'];
+    let botEmail: string;
+
+    if (validRepos.includes(args.repoName)) {
+      botEmail = `${args.repoName.split('/')[1]}@linz.govt.nz`;
+    }
+    else {
+      throw new Error(`${args.repoName} is not a valid GitHub repository`);
+    }
 
     // Load information from the template inside the repo
     logger.info({ template: fsa.joinAll('template', 'catalog.json') }, 'Stac:ReadTemplate');
@@ -83,7 +92,7 @@ export const commandStacGithubImport = command({
     const collectionFile = { path: targetCollectionPath, content: collectionFileContent };
     logger.info({ commit: `feat: import ${collection.title}`, branch: `feat/bot-${collection.id}` }, 'Git:Commit');
     // create pull request
-    await createPR(gh, branch, title, [collectionFile]);
+    await createPR(gh, branch, title, botEmail, [collectionFile]);
   },
 });
 

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -115,7 +115,7 @@ export class GithubApi {
   /**
    * Create a file imagery config file into basemaps-config/config/imagery and commit
    */
-  async createCommit(blobs: Blob[], message: string, authorEmail: string, sha: string): Promise<string> {
+  async createCommit(blobs: Blob[], message: string, botEmail: string, sha: string): Promise<string> {
     // Create a tree which defines the folder structure
     logger.debug({ sha }, 'GitHub API: Create Tree');
     const treeRes = await this.octokit.rest.git.createTree({
@@ -136,7 +136,7 @@ export class GithubApi {
       message,
       author: {
         name: 'linz-li-bot',
-        email: authorEmail,
+        email: botEmail,
       },
       parents: [sha],
       tree: treeSha,
@@ -191,7 +191,7 @@ export async function createPR(
   gh: GithubApi,
   branch: string,
   title: string,
-  authorEmail: string,
+  botEmail: string,
   files: GithubFiles[],
 ): Promise<number> {
   // git checkout -b
@@ -212,7 +212,7 @@ export async function createPR(
 
   // git commit
   logger.info({ branch }, 'GitHub: Commit to Branch');
-  const commitSha = await gh.createCommit(blobs, title, authorEmail, sha);
+  const commitSha = await gh.createCommit(blobs, title, botEmail, sha);
 
   // git push
   logger.info({ branch }, 'GitHub: Push commit to Branch');

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -115,7 +115,7 @@ export class GithubApi {
   /**
    * Create a file imagery config file into basemaps-config/config/imagery and commit
    */
-  async createCommit(blobs: Blob[], message: string, sha: string): Promise<string> {
+  async createCommit(blobs: Blob[], message: string, authorEmail: string, sha: string): Promise<string> {
     // Create a tree which defines the folder structure
     logger.debug({ sha }, 'GitHub API: Create Tree');
     const treeRes = await this.octokit.rest.git.createTree({
@@ -134,6 +134,10 @@ export class GithubApi {
       owner: this.owner,
       repo: this.repo,
       message,
+      author: {
+        name: 'linz-li-bot',
+        email: authorEmail,
+      },
       parents: [sha],
       tree: treeSha,
     });
@@ -183,7 +187,13 @@ export interface GithubFiles {
  *
  * @returns pull request number
  */
-export async function createPR(gh: GithubApi, branch: string, title: string, files: GithubFiles[]): Promise<number> {
+export async function createPR(
+  gh: GithubApi,
+  branch: string,
+  title: string,
+  authorEmail: string,
+  files: GithubFiles[],
+): Promise<number> {
   // git checkout -b
   logger.info({ branch }, 'GitHub: Get branch');
   let sha = await gh.getBranch(branch);
@@ -202,7 +212,7 @@ export async function createPR(gh: GithubApi, branch: string, title: string, fil
 
   // git commit
   logger.info({ branch }, 'GitHub: Commit to Branch');
-  const commitSha = await gh.createCommit(blobs, title, sha);
+  const commitSha = await gh.createCommit(blobs, title, authorEmail, sha);
 
   // git push
   logger.info({ branch }, 'GitHub: Push commit to Branch');


### PR DESCRIPTION
#### Motivation

Pass through an email address associated with the repository that the PR is for.

#### Modification

Set the Git commit author email depending on whether the repo is for `basemaps-config`, `elevation`, or `imagery`.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [X] Issue linked in Title
