### PR TITLE
feat: Slugify strings TDE-1019

### DIFF
--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -36,12 +36,12 @@ describe('slugify', () => {
   it('should treat any unhandled characters as an error', () => {
     assert.throws(
       () => {
-        slugify('“a\\b//c;\n”');
+        slugify('“a\\b//c—;\n”');
       },
       {
         name: 'UnhandledCharactersError',
-        message: 'Unhandled characters: "\\n", "/", ";", "\\", "“", "”"',
-        characters: ['\n', '/', ';', '\\', '“', '”'],
+        message: 'Unhandled characters: "\\n", "/", ";", "\\", "—", "“", "”"',
+        characters: ['\n', '/', ';', '\\', '—', '“', '”'],
       },
     );
   });

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { outputAlphabet, slugify } from '../slugify.js';
+import { slugify } from '../slugify.js';
 
 describe('slugify', () => {
   it('should pass through output alphabet unchanged', () => {
-    assert.equal(slugify(outputAlphabet), outputAlphabet);
+    assert.equal(slugify('abcdefghijklmnopqrstuvwxyz0123456789_.-'), 'abcdefghijklmnopqrstuvwxyz0123456789_.-');
   });
   it('should lowercase uppercase ASCII characters', () => {
     assert.equal(slugify('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'abcdefghijklmnopqrstuvwxyz');

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { slugify } from '../slugify.js';
+
+const outputAlphabet = 'abcdefghijklmnopqrstuvwxyz0123456789_.-';
+
+describe('slugify', () => {
+  it('should pass through output alphabet unchanged', () => {
+    assert.equal(slugify(outputAlphabet), outputAlphabet);
+  });
+});

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -14,7 +14,21 @@ describe('slugify', () => {
     assert.equal(slugify('Upper North Island'), 'upper-north-island');
   });
   it('should remove diacritics', () => {
-    assert.equal(slugify('äéìôūÄÉÌÔŪ'), 'aeiouaeiou');
+    ['á', 'Á', 'ä', 'Ä', 'ā', 'Ā'].forEach((value) => {
+      assert.equal(slugify(value), 'a');
+    });
+    ['é', 'É', 'ē', 'Ē'].forEach((value) => {
+      assert.equal(slugify(value), 'e');
+    });
+    ['ì', 'Ì', 'ī', 'Ī'].forEach((value) => {
+      assert.equal(slugify(value), 'i');
+    });
+    ['ó', 'Ó', 'ô', 'Ô', 'ö', 'Ö', 'ō', 'Ō'].forEach((value) => {
+      assert.equal(slugify(value), 'o');
+    });
+    ['ü', 'Ü', 'ū', 'Ū'].forEach((value) => {
+      assert.equal(slugify(value), 'u');
+    });
   });
   it('should handle decomposed characters', () => {
     assert.equal(slugify('\u0041\u0304'), 'a');

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -44,9 +44,9 @@ describe('slugify', () => {
         slugify('“a\\b//c—;\n”');
       },
       {
-        name: 'UnhandledCharactersError',
+        name: 'Error',
         message: 'Unhandled characters: "\\n", "/", ";", "\\", "—", "“", "”"',
-        characters: ['\n', '/', ';', '\\', '—', '“', '”'],
+        cause: { characters: ['\n', '/', ';', '\\', '—', '“', '”'] },
       },
     );
   });

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -12,7 +12,10 @@ describe('slugify', () => {
   it('should lowercase uppercase ASCII characters', () => {
     assert.equal(slugify('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'abcdefghijklmnopqrstuvwxyz');
   });
-  it('should transliterate macronated characters', () => {
-    assert.equal(slugify('āēīōūĀĒĪŌŪ'), 'aeiouaeiou');
+  it('should remove diacritics', () => {
+    assert.equal(slugify('äéìôūÄÉÌÔŪ'), 'aeiouaeiou');
+  });
+  it('should handle decomposed characters', () => {
+    assert.equal(slugify('\u0041\u0304'), 'a');
   });
 });

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -36,12 +36,12 @@ describe('slugify', () => {
   it('should treat any unhandled characters as an error', () => {
     assert.throws(
       () => {
-        slugify('a\\b//c;\n');
+        slugify('“a\\b//c;\n”');
       },
       {
         name: 'UnhandledCharactersError',
-        message: 'Unhandled characters: "\\n", "/", ";", "\\"',
-        characters: ['\n', '/', ';', '\\'],
+        message: 'Unhandled characters: "\\n", "/", ";", "\\", "“", "”"',
+        characters: ['\n', '/', ';', '\\', '“', '”'],
       },
     );
   });

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -22,12 +22,12 @@ describe('slugify', () => {
   it('should treat any unhandled characters as an error', () => {
     assert.throws(
       () => {
-        slugify('a\\b//c');
+        slugify('a\\b//c;\n');
       },
       {
         name: 'UnhandledCharactersError',
-        message: 'Unhandled characters: "/", "\\"',
-        characters: ['/', '\\'],
+        message: 'Unhandled characters: "\\n", "/", ";", "\\"',
+        characters: ['\n', '/', ';', '\\'],
       },
     );
   });

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -12,4 +12,7 @@ describe('slugify', () => {
   it('should lowercase uppercase ASCII characters', () => {
     assert.equal(slugify('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'abcdefghijklmnopqrstuvwxyz');
   });
+  it('should transliterate macronated characters', () => {
+    assert.equal(slugify('āēīōūĀĒĪŌŪ'), 'aeiouaeiou');
+  });
 });

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -12,6 +12,9 @@ describe('slugify', () => {
   it('should lowercase uppercase ASCII characters', () => {
     assert.equal(slugify('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'abcdefghijklmnopqrstuvwxyz');
   });
+  it('should replace spaces with hyphens', () => {
+    assert.equal(slugify('Upper North Island'), 'upper-north-island');
+  });
   it('should remove diacritics', () => {
     assert.equal(slugify('äéìôūÄÉÌÔŪ'), 'aeiouaeiou');
   });

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -23,7 +23,7 @@ describe('slugify', () => {
     ['ì', 'Ì', 'ī', 'Ī'].forEach((value) => {
       assert.equal(slugify(value), 'i');
     });
-    ['ó', 'Ó', 'ô', 'Ô', 'ö', 'Ö', 'ō', 'Ō'].forEach((value) => {
+    ['ó', 'Ó', 'ô', 'Ô', 'ö', 'Ö', 'ø', 'Ø', 'ō', 'Ō'].forEach((value) => {
       assert.equal(slugify(value), 'o');
     });
     ['ü', 'Ü', 'ū', 'Ū'].forEach((value) => {

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -23,11 +23,16 @@ describe('slugify', () => {
     ['ì', 'Ì', 'ī', 'Ī'].forEach((value) => {
       assert.equal(slugify(value), 'i');
     });
-    ['ó', 'Ó', 'ô', 'Ô', 'ö', 'Ö', 'ø', 'Ø', 'ō', 'Ō'].forEach((value) => {
+    ['ó', 'Ó', 'ô', 'Ô', 'ö', 'Ö', 'ō', 'Ō'].forEach((value) => {
       assert.equal(slugify(value), 'o');
     });
     ['ü', 'Ü', 'ū', 'Ū'].forEach((value) => {
       assert.equal(slugify(value), 'u');
+    });
+  });
+  it('should convert "ø" (U+00F8) and "Ø" (U+00D8) to "o"', () => {
+    ['ø', 'Ø'].forEach((value) => {
+      assert.equal(slugify(value), 'o');
     });
   });
   it('should handle decomposed characters', () => {

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -1,9 +1,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { slugify } from '../slugify.js';
-
-const outputAlphabet = 'abcdefghijklmnopqrstuvwxyz0123456789_.-';
+import { outputAlphabet, slugify } from '../slugify.js';
 
 describe('slugify', () => {
   it('should pass through output alphabet unchanged', () => {
@@ -20,5 +18,17 @@ describe('slugify', () => {
   });
   it('should handle decomposed characters', () => {
     assert.equal(slugify('\u0041\u0304'), 'a');
+  });
+  it('should treat any unhandled characters as an error', () => {
+    assert.throws(
+      () => {
+        slugify('a\\b//c');
+      },
+      {
+        name: 'UnhandledCharactersError',
+        message: 'Unhandled characters: "/", "\\"',
+        characters: ['/', '\\'],
+      },
+    );
   });
 });

--- a/src/utils/__test__/slugify.test.ts
+++ b/src/utils/__test__/slugify.test.ts
@@ -9,4 +9,7 @@ describe('slugify', () => {
   it('should pass through output alphabet unchanged', () => {
     assert.equal(slugify(outputAlphabet), outputAlphabet);
   });
+  it('should lowercase uppercase ASCII characters', () => {
+    assert.equal(slugify('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'abcdefghijklmnopqrstuvwxyz');
+  });
 });

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,3 +1,5 @@
+const combiningMacronCharacter = '\u0304';
+
 export function slugify(input: string): string {
-  return input.toLowerCase();
+  return input.normalize('NFD').replaceAll(combiningMacronCharacter, '').toLowerCase();
 }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -23,7 +23,7 @@ function removeDiacritics(input: string): string {
 }
 
 class UnhandledCharactersError extends Error {
-  public characters: string[];
+  public characters: string[]; // For ease of use in callers which might want to provide a more helpful message
 
   constructor(characters: string[]) {
     const formattedCharacters = characters.map((character) => {

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,3 +1,15 @@
+export function slugify(input: string): string {
+  const result = removeDiacritics(input).replaceAll(' ', '-').toLowerCase();
+
+  const unhandledCharacters = result.match(unhandledCharactersRegExp);
+  if (unhandledCharacters) {
+    const sortedUniqueCharacters = Array.from(new Set(unhandledCharacters)).sort();
+    throw new UnhandledCharactersError(sortedUniqueCharacters);
+  }
+
+  return result;
+}
+
 const unhandledCharactersRegExp = /[^abcdefghijklmnopqrstuvwxyz0123456789_.-]/g;
 
 const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
@@ -22,16 +34,4 @@ class UnhandledCharactersError extends Error {
     this.name = 'UnhandledCharactersError';
     this.characters = characters;
   }
-}
-
-export function slugify(input: string): string {
-  const result = removeDiacritics(input).replaceAll(' ', '-').toLowerCase();
-
-  const unhandledCharacters = result.match(unhandledCharactersRegExp);
-  if (unhandledCharacters) {
-    const sortedUniqueCharacters = Array.from(new Set(unhandledCharacters)).sort();
-    throw new UnhandledCharactersError(sortedUniqueCharacters);
-  }
-
-  return result;
 }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -13,10 +13,10 @@ export function slugify(input: string): string {
 }
 
 function removeDiacritics(input: string): string {
-  /*
-   Normalization form decomposition (NFD) splits characters like into their
-   [combining diacritical mark](https://www.unicode.org/charts/PDF/U0300.pdf) and the character which is being modified
-   by the diacritic. This way we can remove the macron from "ā", the accent from "é", and the like.
+  /**
+   * Normalization form decomposition (NFD) splits characters like into their
+   * [combining diacritical mark](https://www.unicode.org/charts/PDF/U0300.pdf) and the character which is being modified
+   * by the diacritic. This way we can remove the macron from "ā", the accent from "é", and the like.
    */
   const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
   return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '');

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -20,7 +20,7 @@ export function slugify(input: string): string {
 }
 
 /**
- * Normalization form decomposition (NFD) splits characters like into their
+ * Normalization form decomposition (NFD) splits characters like "ā" into their
  * [combining diacritical mark](https://www.unicode.org/charts/PDF/U0300.pdf) and the character which is being modified
  * by the diacritic. This way we can remove the macron from "ā", the accent from "é", and the like.
  */

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,3 @@
+export function slugify(input: string): string {
+  return input;
+}

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,5 +1,8 @@
 export function slugify(input: string): string {
-  // See src/utils/__test__/slugify.test.ts for examples
+  /**
+   * @param input Human-readable string
+   * @returns String slug. See src/utils/__test__/slugify.test.ts for examples.
+   */
 
   const result = removeDiacritics(input).replaceAll('ø', 'o').replaceAll('Ø', 'O').replaceAll(' ', '-').toLowerCase();
 

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,5 +1,10 @@
-const combiningMacronCharacter = '\u0304';
+const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
 
 export function slugify(input: string): string {
-  return input.normalize('NFD').replaceAll(combiningMacronCharacter, '').toLowerCase();
+  /*
+   Normalization form decomposition (NFD) splits characters like into their
+   [combining diacritical mark](https://www.unicode.org/charts/PDF/U0300.pdf) and the character which is being modified
+   by the diacritic. This way we can remove the macron from "ā", the accent from "é", and the like.
+   */
+  return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '').toLowerCase();
 }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,4 +1,6 @@
 export function slugify(input: string): string {
+  // See src/utils/__test__/slugify.test.ts for examples
+
   const result = removeDiacritics(input).replaceAll(' ', '-').toLowerCase();
 
   const unhandledCharacters = result.match(/[^abcdefghijklmnopqrstuvwxyz0123456789_.-]/g);

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,3 +1,6 @@
+export const outputAlphabet = 'abcdefghijklmnopqrstuvwxyz0123456789_.-';
+const unhandledCharactersRegExp = new RegExp(`[^${outputAlphabet}]`, 'g');
+
 const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
 
 function removeDiacritics(input: string): string {
@@ -9,6 +12,24 @@ function removeDiacritics(input: string): string {
   return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '');
 }
 
+class UnhandledCharactersError extends Error {
+  public characters: string[];
+
+  constructor(characters: string[]) {
+    super(`Unhandled characters: "${characters.join('", "')}"`);
+    this.name = 'UnhandledCharactersError';
+    this.characters = characters;
+  }
+}
+
 export function slugify(input: string): string {
-  return removeDiacritics(input).replaceAll(' ', '-').toLowerCase();
+  const result = removeDiacritics(input).replaceAll(' ', '-').toLowerCase();
+
+  const unhandledCharacters = result.match(unhandledCharactersRegExp);
+  if (unhandledCharacters) {
+    const sortedUniqueCharacters = Array.from(new Set(unhandledCharacters)).sort();
+    throw new UnhandledCharactersError(sortedUniqueCharacters);
+  }
+
+  return result;
 }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,3 +1,3 @@
 export function slugify(input: string): string {
-  return input;
+  return input.toLowerCase();
 }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -16,7 +16,10 @@ class UnhandledCharactersError extends Error {
   public characters: string[];
 
   constructor(characters: string[]) {
-    super(`Unhandled characters: "${characters.join('", "')}"`);
+    const formattedCharacters = characters.map((character) => {
+      return JSON.stringify(character).replaceAll('\\\\', '\\');
+    });
+    super(`Unhandled characters: ${formattedCharacters.join(', ')}`);
     this.name = 'UnhandledCharactersError';
     this.characters = characters;
   }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,7 +1,7 @@
 export function slugify(input: string): string {
   const result = removeDiacritics(input).replaceAll(' ', '-').toLowerCase();
 
-  const unhandledCharacters = result.match(unhandledCharactersRegExp);
+  const unhandledCharacters = result.match(/[^abcdefghijklmnopqrstuvwxyz0123456789_.-]/g);
   if (unhandledCharacters) {
     const sortedUniqueCharacters = Array.from(new Set(unhandledCharacters)).sort();
     throw new UnhandledCharactersError(sortedUniqueCharacters);
@@ -9,8 +9,6 @@ export function slugify(input: string): string {
 
   return result;
 }
-
-const unhandledCharactersRegExp = /[^abcdefghijklmnopqrstuvwxyz0123456789_.-]/g;
 
 const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
 

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,10 +1,14 @@
 const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
 
-export function slugify(input: string): string {
+function removeDiacritics(input: string): string {
   /*
    Normalization form decomposition (NFD) splits characters like into their
    [combining diacritical mark](https://www.unicode.org/charts/PDF/U0300.pdf) and the character which is being modified
    by the diacritic. This way we can remove the macron from "ā", the accent from "é", and the like.
    */
-  return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '').replaceAll(' ', '-').toLowerCase();
+  return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '');
+}
+
+export function slugify(input: string): string {
+  return removeDiacritics(input).replaceAll(' ', '-').toLowerCase();
 }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -10,14 +10,13 @@ export function slugify(input: string): string {
   return result;
 }
 
-const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
-
 function removeDiacritics(input: string): string {
   /*
    Normalization form decomposition (NFD) splits characters like into their
    [combining diacritical mark](https://www.unicode.org/charts/PDF/U0300.pdf) and the character which is being modified
    by the diacritic. This way we can remove the macron from "ā", the accent from "é", and the like.
    */
+  const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
   return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '');
 }
 

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -9,7 +9,12 @@ export function slugify(input: string): string {
   const unhandledCharacters = result.match(/[^abcdefghijklmnopqrstuvwxyz0123456789_.-]/g);
   if (unhandledCharacters) {
     const sortedUniqueCharacters = Array.from(new Set(unhandledCharacters)).sort();
-    throw new UnhandledCharactersError(sortedUniqueCharacters);
+    const formattedCharacters = sortedUniqueCharacters.map((character) => {
+      return JSON.stringify(character).replaceAll('\\\\', '\\');
+    });
+    throw Error(`Unhandled characters: ${formattedCharacters.join(', ')}`, {
+      cause: { characters: sortedUniqueCharacters },
+    });
   }
 
   return result;
@@ -23,17 +28,4 @@ function removeDiacritics(input: string): string {
    */
   const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
   return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '');
-}
-
-class UnhandledCharactersError extends Error {
-  public characters: string[]; // For ease of use in callers which might want to provide a more helpful message
-
-  constructor(characters: string[]) {
-    const formattedCharacters = characters.map((character) => {
-      return JSON.stringify(character).replaceAll('\\\\', '\\');
-    });
-    super(`Unhandled characters: ${formattedCharacters.join(', ')}`);
-    this.name = 'UnhandledCharactersError';
-    this.characters = characters;
-  }
 }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -6,5 +6,5 @@ export function slugify(input: string): string {
    [combining diacritical mark](https://www.unicode.org/charts/PDF/U0300.pdf) and the character which is being modified
    by the diacritic. This way we can remove the macron from "ā", the accent from "é", and the like.
    */
-  return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '').toLowerCase();
+  return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '').replaceAll(' ', '-').toLowerCase();
 }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,9 +1,8 @@
+/**
+ * @param input Human-readable string
+ * @returns String slug. See src/utils/__test__/slugify.test.ts for examples.
+ */
 export function slugify(input: string): string {
-  /**
-   * @param input Human-readable string
-   * @returns String slug. See src/utils/__test__/slugify.test.ts for examples.
-   */
-
   const result = removeDiacritics(input).replaceAll('ø', 'o').replaceAll('Ø', 'O').replaceAll(' ', '-').toLowerCase();
 
   const unhandledCharacters = result.match(/[^abcdefghijklmnopqrstuvwxyz0123456789_.-]/g);
@@ -20,12 +19,12 @@ export function slugify(input: string): string {
   return result;
 }
 
+/**
+ * Normalization form decomposition (NFD) splits characters like into their
+ * [combining diacritical mark](https://www.unicode.org/charts/PDF/U0300.pdf) and the character which is being modified
+ * by the diacritic. This way we can remove the macron from "ā", the accent from "é", and the like.
+ */
 function removeDiacritics(input: string): string {
-  /**
-   * Normalization form decomposition (NFD) splits characters like into their
-   * [combining diacritical mark](https://www.unicode.org/charts/PDF/U0300.pdf) and the character which is being modified
-   * by the diacritic. This way we can remove the macron from "ā", the accent from "é", and the like.
-   */
   const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
   return input.normalize('NFD').replaceAll(combiningDiacriticalMarks, '');
 }

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,7 +1,7 @@
 export function slugify(input: string): string {
   // See src/utils/__test__/slugify.test.ts for examples
 
-  const result = removeDiacritics(input).replaceAll(' ', '-').toLowerCase();
+  const result = removeDiacritics(input).replaceAll('ø', 'o').replaceAll('Ø', 'O').replaceAll(' ', '-').toLowerCase();
 
   const unhandledCharacters = result.match(/[^abcdefghijklmnopqrstuvwxyz0123456789_.-]/g);
   if (unhandledCharacters) {

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,5 +1,4 @@
-export const outputAlphabet = 'abcdefghijklmnopqrstuvwxyz0123456789_.-';
-const unhandledCharactersRegExp = new RegExp(`[^${outputAlphabet}]`, 'g');
+const unhandledCharactersRegExp = /[^abcdefghijklmnopqrstuvwxyz0123456789_.-]/g;
 
 const combiningDiacriticalMarks = /[\u0300-\u036F]/g;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@linzjs/style/tsconfig.base.json",
   "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
     "outDir": "build"
   }
 }


### PR DESCRIPTION
#### Motivation

Allow us to easily slugify arbitrary strings for use in URLs.

#### Modification

This assumes that each part of a path will be slugified separately. This is less convenient than slugifying the entire path in one go, but ensures that no path segment contains a slash.

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated (comments only)
- [x] Issue linked in Title
