### PR TITLE
fix: handle 1:50k imagery TDE-1014 TDE-1015

### DIFF
--- a/src/commands/create-manifest/__test__/create-manifest.test.ts
+++ b/src/commands/create-manifest/__test__/create-manifest.test.ts
@@ -87,12 +87,12 @@ describe('createManifest', () => {
     ]);
   });
   describe('validatePaths', () => {
-    it('Should throw error for Missmatch Paths', () => {
+    it('Should throw error for Mismatched Paths', () => {
       assert.throws(() => {
         validatePaths('memory://source/', 'memory://target/sub/test.tiff');
       }, Error);
     });
-    it('Should also throw error for Missmatch Paths', () => {
+    it('Should also throw error for Mismatched Paths', () => {
       assert.throws(() => {
         validatePaths('memory://source/test.tiff', 'memory://target/sub/');
       }, Error);

--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -36,12 +36,16 @@ describe('getTileName', () => {
     assert.equal(convertTileName('CH11_1000_0501', 5000), 'CH11_5000_0101');
     assert.equal(convertTileName('CH11_1000_0505', 5000), 'CH11_5000_0101');
   });
-
   it('should get correct parent tile 1:10k', () => {
     assert.equal(convertTileName('CH11_1000_0101', 10000), 'CH11_10000_0101');
     assert.equal(convertTileName('CH11_1000_0110', 10000), 'CH11_10000_0101');
     assert.equal(convertTileName('CH11_1000_1010', 10000), 'CH11_10000_0101');
     assert.equal(convertTileName('CH11_1000_1001', 10000), 'CH11_10000_0101');
+  });
+  it('should get correct parent tile 1:50k', () => {
+    assert.equal(convertTileName('AT24_50000_0101', 50000), 'AT24_50000_0101');
+    assert.equal(convertTileName('AT25_50000_0101', 50000), 'AT25_50000_0101');
+    assert.equal(convertTileName('CK08_50000_0101', 50000), 'CK08_50000_0101');
   });
 });
 describe('tiffLocation', () => {

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -341,37 +341,37 @@ export function validateTiffAlignment(tiff: TiffLocation, allowedError = 0.015):
   return true;
 }
 
-export function getTileName(centerX: number, centerY: number, grid_size: number): string {
-  if (!MapSheet.gridSizes.includes(grid_size)) {
+export function getTileName(x: number, y: number, gridSize: number): string {
+  if (!MapSheet.gridSizes.includes(gridSize)) {
     throw new Error(`The scale has to be one of the following values: ${MapSheet.gridSizes}`);
   }
 
-  const scale = Math.floor(MapSheet.gridSizeMax / grid_size);
-  const tile_width = Math.floor(MapSheet.width / scale);
-  const tile_height = Math.floor(MapSheet.height / scale);
-  let nb_digits = 2;
-  if (grid_size === 500) {
-    nb_digits = 3;
+  const scale = Math.floor(MapSheet.gridSizeMax / gridSize);
+  const tileWidth = Math.floor(MapSheet.width / scale);
+  const tileHeight = Math.floor(MapSheet.height / scale);
+  let nbDigits = 2;
+  if (gridSize === 500) {
+    nbDigits = 3;
   }
 
-  if (!(SHEET_MIN_X <= centerX && centerX <= SHEET_MAX_X)) {
-    throw new Error(`x must be between ${SHEET_MIN_X} and ${SHEET_MAX_X}, was ${centerX}`);
+  if (!(SHEET_MIN_X <= x && x <= SHEET_MAX_X)) {
+    throw new Error(`x must be between ${SHEET_MIN_X} and ${SHEET_MAX_X}, was ${x}`);
   }
-  if (!(SHEET_MIN_Y <= centerY && centerY <= SHEET_MAX_Y)) {
-    throw new Error(`y must be between ${SHEET_MIN_Y} and ${SHEET_MAX_Y}, was ${centerY}`);
+  if (!(SHEET_MIN_Y <= y && y <= SHEET_MAX_Y)) {
+    throw new Error(`y must be between ${SHEET_MIN_Y} and ${SHEET_MAX_Y}, was ${y}`);
   }
 
   // Do some maths
-  const offset_x = Math.round(Math.floor((centerX - MapSheet.origin.x) / MapSheet.width));
-  const offset_y = Math.round(Math.floor((MapSheet.origin.y - centerY) / MapSheet.height));
-  const max_y = MapSheet.origin.y - offset_y * MapSheet.height;
-  const min_x = MapSheet.origin.x + offset_x * MapSheet.width;
-  const tile_x = Math.round(Math.floor((centerX - min_x) / tile_width + 1));
-  const tile_y = Math.round(Math.floor((max_y - centerY) / tile_height + 1));
+  const offsetX = Math.round(Math.floor((x - MapSheet.origin.x) / MapSheet.width));
+  const offsetY = Math.round(Math.floor((MapSheet.origin.y - y) / MapSheet.height));
+  const maxY = MapSheet.origin.y - offsetY * MapSheet.height;
+  const minX = MapSheet.origin.x + offsetX * MapSheet.width;
+  const tileX = Math.round(Math.floor((x - minX) / tileWidth + 1));
+  const tileY = Math.round(Math.floor((maxY - y) / tileHeight + 1));
 
   // Build name
-  const letters = Object.keys(SheetRanges)[offset_y];
-  const sheet_code = `${letters}${`${offset_x}`.padStart(2, '0')}`;
-  const tile_id = `${`${tile_y}`.padStart(nb_digits, '0')}${`${tile_x}`.padStart(nb_digits, '0')}`;
-  return `${sheet_code}_${grid_size}_${tile_id}`;
+  const letters = Object.keys(SheetRanges)[offsetY];
+  const sheetCode = `${letters}${`${offsetX}`.padStart(2, '0')}`;
+  const tileId = `${`${tileY}`.padStart(nbDigits, '0')}${`${tileX}`.padStart(nbDigits, '0')}`;
+  return `${sheetCode}_${gridSize}_${tileId}`;
 }

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -14,7 +14,7 @@ import { CommandListArgs } from '../list/list.js';
 
 const SHEET_MIN_X = MapSheet.origin.x + 4 * MapSheet.width; // The minimum x coordinate of a valid sheet / tile
 const SHEET_MAX_X = MapSheet.origin.x + 46 * MapSheet.width; // The maximum x coordinate of a valid sheet / tile
-const SHEET_MIN_Y = MapSheet.origin.y - 41 * MapSheet.height; // The minimum y coordinate of a valid sheet / tile
+const SHEET_MIN_Y = MapSheet.origin.y - 42 * MapSheet.height; // The minimum y coordinate of a valid sheet / tile
 const SHEET_MAX_Y = MapSheet.origin.y; // The maximum y coordinate of a valid sheet / tile
 
 export function isTiff(x: string): boolean {
@@ -341,7 +341,7 @@ export function validateTiffAlignment(tiff: TiffLocation, allowedError = 0.015):
   return true;
 }
 
-export function getTileName(originX: number, originY: number, grid_size: number): string {
+export function getTileName(centerX: number, centerY: number, grid_size: number): string {
   if (!MapSheet.gridSizes.includes(grid_size)) {
     throw new Error(`The scale has to be one of the following values: ${MapSheet.gridSizes}`);
   }
@@ -354,24 +354,29 @@ export function getTileName(originX: number, originY: number, grid_size: number)
     nb_digits = 3;
   }
 
-  if (!(SHEET_MIN_X <= originX && originX <= SHEET_MAX_X)) {
-    throw new Error(`x must be between ${SHEET_MIN_X} and ${SHEET_MAX_X}, was ${originX}`);
+  if (!(SHEET_MIN_X <= centerX && centerX <= SHEET_MAX_X)) {
+    throw new Error(`x must be between ${SHEET_MIN_X} and ${SHEET_MAX_X}, was ${centerX}`);
   }
-  if (!(SHEET_MIN_Y <= originY && originY <= SHEET_MAX_Y)) {
-    throw new Error(`y must be between ${SHEET_MIN_Y} and ${SHEET_MAX_Y}, was ${originY}`);
+  if (!(SHEET_MIN_Y <= centerY && centerY <= SHEET_MAX_Y)) {
+    throw new Error(`y must be between ${SHEET_MIN_Y} and ${SHEET_MAX_Y}, was ${centerY}`);
   }
 
   // Do some maths
-  const offset_x = Math.round(Math.floor((originX - MapSheet.origin.x) / MapSheet.width));
-  const offset_y = Math.round(Math.floor((MapSheet.origin.y - originY) / MapSheet.height));
+  const offset_x = Math.round(Math.floor((centerX - MapSheet.origin.x) / MapSheet.width));
+  const offset_y = Math.round(Math.floor((MapSheet.origin.y - centerY) / MapSheet.height));
   const max_y = MapSheet.origin.y - offset_y * MapSheet.height;
   const min_x = MapSheet.origin.x + offset_x * MapSheet.width;
-  const tile_x = Math.round(Math.floor((originX - min_x) / tile_width + 1));
-  const tile_y = Math.round(Math.floor((max_y - originY) / tile_height + 1));
+  const tile_x = Math.round(Math.floor((centerX - min_x) / tile_width + 1));
+  const tile_y = Math.round(Math.floor((max_y - centerY) / tile_height + 1));
 
   // Build name
   const letters = Object.keys(SheetRanges)[offset_y];
   const sheet_code = `${letters}${`${offset_x}`.padStart(2, '0')}`;
   const tile_id = `${`${tile_y}`.padStart(nb_digits, '0')}${`${tile_x}`.padStart(nb_digits, '0')}`;
+  // if (grid_size === 50_000) {
+  //   return sheet_code;
+  // } else {
+  //   return `${sheet_code}_${grid_size}_${tile_id}`;
+  // }
   return `${sheet_code}_${grid_size}_${tile_id}`;
 }

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -373,10 +373,5 @@ export function getTileName(centerX: number, centerY: number, grid_size: number)
   const letters = Object.keys(SheetRanges)[offset_y];
   const sheet_code = `${letters}${`${offset_x}`.padStart(2, '0')}`;
   const tile_id = `${`${tile_y}`.padStart(nb_digits, '0')}${`${tile_x}`.padStart(nb_digits, '0')}`;
-  // if (grid_size === 50_000) {
-  //   return sheet_code;
-  // } else {
-  //   return `${sheet_code}_${grid_size}_${tile_id}`;
-  // }
   return `${sheet_code}_${grid_size}_${tile_id}`;
 }

--- a/src/utils/__test__/mapsheet.test.ts
+++ b/src/utils/__test__/mapsheet.test.ts
@@ -19,6 +19,20 @@ describe('MapSheets', () => {
     });
   });
 
+  it('should generate 1:50k name', () => {
+    assert.deepEqual(MapSheet.extract('CK08_50000_0101.tiff'), {
+      mapSheet: 'CK08',
+      gridSize: 50000,
+      x: 1,
+      y: 1,
+      name: 'CK08',
+      origin: { x: 1180000, y: 4758000 },
+      width: 24000,
+      height: 36000,
+      bbox: [1180000, 4722000, 1204000, 4758000],
+    });
+  });
+
   it('should iterate mapsheets', () => {
     const sheets = [...MapSheet.iterate()];
     assert.deepEqual(sheets, ExpectedCodes);
@@ -29,6 +43,7 @@ describe('MapSheets', () => {
     assert.deepEqual(MapSheet.offset('AS21'), { x: 1492000, y: 6234000 });
     assert.deepEqual(MapSheet.offset('BG33'), { x: 1780000, y: 5730000 });
     assert.deepEqual(MapSheet.offset('BW14'), { x: 1324000, y: 5226000 });
+    assert.deepEqual(MapSheet.offset('CK08'), { x: 1180000, y: 4758000 });
   });
 
   for (const ms of MapSheetData) {

--- a/src/utils/mapsheet.ts
+++ b/src/utils/mapsheet.ts
@@ -89,7 +89,7 @@ export const MapSheet = {
   gridSizeMax: 50000,
   roundCorrection: 0.01,
   /** Allowed grid sizes, these should exist in the LINZ Data service (meters) */
-  gridSizes: [10_000, 5_000, 2_000, 1_000, 500],
+  gridSizes: [50_000, 10_000, 5_000, 2_000, 1_000, 500],
 
   /**
    * Get the expected origin and mapsheet information from a file name
@@ -122,6 +122,10 @@ export const MapSheet = {
     } else {
       out.y = Number(match[3]?.slice(0, 2));
       out.x = Number(match[3]?.slice(2));
+    }
+    // 1:50_000 uses map sheet as filename e.g. CK08.tiff
+    if (out.gridSize === 50_000) {
+      out.name = out.mapSheet;
     }
     if (isNaN(out.gridSize) || isNaN(out.x) || isNaN(out.y)) return null;
 


### PR DESCRIPTION
#### Motivation

Allow the use of 1:50k scale imagery.

Note: there will be a separate pull request for [tileset-validation logs errors](https://toitutewhenua.atlassian.net/browse/TDE-1013).
#### Modification

Handle 1:50000 grid size, and generate the [correct name for this imagery](https://toitutewhenua.atlassian.net/browse/TDE-1014) (map sheet name only). It also fixes a [bug where the bottom row of map sheets were not considered valid](https://toitutewhenua.atlassian.net/browse/TDE-1015).

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated (comments only)
- [X] Issue linked in Title
