### PR TITLE
 refactor: Use custom type for grid size  TDE-1030

### DIFF
--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -5,11 +5,12 @@ import { fsa } from '@chunkd/fs';
 import { FsMemory } from '@chunkd/source-memory';
 import { FeatureCollection } from 'geojson';
 
-import { MapSheet } from '../../../utils/mapsheet.js';
+import { GridSize, MapSheet } from '../../../utils/mapsheet.js';
 import {
   commandTileIndexValidate,
   extractTiffLocations,
   getTileName,
+  GridSizeFromString,
   groupByTileName,
   TiffLoader,
 } from '../tileindex.validate.js';
@@ -17,10 +18,10 @@ import { FakeCogTiff } from './tileindex.validate.data.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-function convertTileName(fileName: string, scale: number): string | null {
+function convertTileName(fileName: string, gridSize: GridSize): string | null {
   const mapTileIndex = MapSheet.getMapTileIndex(fileName);
   if (mapTileIndex == null) return null;
-  return getTileName(mapTileIndex.bbox[0], mapTileIndex.bbox[3], scale);
+  return getTileName(mapTileIndex.bbox[0], mapTileIndex.bbox[3], gridSize);
 }
 
 describe('getTileName', () => {
@@ -220,4 +221,16 @@ describe('validate', () => {
       }
     });
   }
+});
+
+describe('GridSizeFromString', () => {
+  it('should return grid size number', async () => {
+    assert.equal(await GridSizeFromString.from('500'), 500);
+  });
+  it('should throw error when converting invalid grid size', async () => {
+    await assert.rejects(
+      GridSizeFromString.from('-1'),
+      new Error('Invalid grid size "-1"; valid values: "10000", "5000", "2000", "1000", "500"'),
+    );
+  });
 });

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -342,7 +342,7 @@ export function validateTiffAlignment(tiff: TiffLocation, allowedError = 0.015):
   return true;
 }
 
-export function getTileName(originX: number, originY: number, gridSize: number): string {
+export function getTileName(x: number, y: number, gridSize: number): string {
   if (!MapSheet.gridSizes.includes(gridSize)) {
     throw new Error(`The scale has to be one of the following values: ${MapSheet.gridSizes}`);
   }
@@ -355,20 +355,20 @@ export function getTileName(originX: number, originY: number, gridSize: number):
     nbDigits = 3;
   }
 
-  if (!(SHEET_MIN_X <= originX && originX <= SHEET_MAX_X)) {
-    throw new Error(`x must be between ${SHEET_MIN_X} and ${SHEET_MAX_X}, was ${originX}`);
+  if (!(SHEET_MIN_X <= x && x <= SHEET_MAX_X)) {
+    throw new Error(`x must be between ${SHEET_MIN_X} and ${SHEET_MAX_X}, was ${x}`);
   }
-  if (!(SHEET_MIN_Y <= originY && originY <= SHEET_MAX_Y)) {
-    throw new Error(`y must be between ${SHEET_MIN_Y} and ${SHEET_MAX_Y}, was ${originY}`);
+  if (!(SHEET_MIN_Y <= y && y <= SHEET_MAX_Y)) {
+    throw new Error(`y must be between ${SHEET_MIN_Y} and ${SHEET_MAX_Y}, was ${y}`);
   }
 
   // Do some maths
-  const offsetX = Math.round(Math.floor((originX - MapSheet.origin.x) / MapSheet.width));
-  const offsetY = Math.round(Math.floor((MapSheet.origin.y - originY) / MapSheet.height));
+  const offsetX = Math.round(Math.floor((x - MapSheet.origin.x) / MapSheet.width));
+  const offsetY = Math.round(Math.floor((MapSheet.origin.y - y) / MapSheet.height));
   const maxY = MapSheet.origin.y - offsetY * MapSheet.height;
   const minX = MapSheet.origin.x + offsetX * MapSheet.width;
-  const tileX = Math.round(Math.floor((originX - minX) / tileWidth + 1));
-  const tileY = Math.round(Math.floor((maxY - originY) / tileHeight + 1));
+  const tileX = Math.round(Math.floor((x - minX) / tileWidth + 1));
+  const tileY = Math.round(Math.floor((maxY - y) / tileHeight + 1));
 
   // Build name
   const letters = Object.keys(SheetRanges)[offsetY];

--- a/src/utils/__test__/geotiff.test.ts
+++ b/src/utils/__test__/geotiff.test.ts
@@ -75,9 +75,9 @@ describe('geotiff', () => {
 
   const url = new URL('memory://BX20_500_023098.tif');
   const fakeSource: Source = { url: url, fetch: async () => new ArrayBuffer(1) };
-  it('should not parse a tiff with no information ', () => {
+  it('should not parse a tiff with no information ', async () => {
     // tiff with no location information and no TFW
-    assert.rejects(() => findBoundingBox({ source: fakeSource, images: [] } as unknown as CogTiff));
+    await assert.rejects(() => findBoundingBox({ source: fakeSource, images: [] } as unknown as CogTiff));
   });
 
   it('should parse a tiff with TFW', async () => {

--- a/src/utils/mapsheet.ts
+++ b/src/utils/mapsheet.ts
@@ -56,6 +56,9 @@ export type Bounds = Point & Size;
 const charA = 'A'.charCodeAt(0);
 const charS = 'S'.charCodeAt(0);
 
+export const gridSizes = [10_000, 5_000, 2_000, 1_000, 500] as const;
+export type GridSize = (typeof gridSizes)[number];
+
 /**
  * Topographic 1:50k map sheet calculator
  *
@@ -86,7 +89,7 @@ export const MapSheet = {
   gridSizeMax: 50000,
   roundCorrection: 0.01,
   /** Allowed grid sizes, these should exist in the LINZ Data service (meters) */
-  gridSizes: [10_000, 5_000, 2_000, 1_000, 500],
+  gridSizes: gridSizes,
 
   /**
    * Get the expected origin and mapsheet information from a file name


### PR DESCRIPTION
#### Motivation

Simplify TDE-1010 implementation

#### Modification

Rename parameters for clarity, use custom type for grid size, and make sure to wait for promise rejection.

#### Checklist

- [x] Tests updated
- [ ] Docs updated (N/A)
- [x] Issue linked in Title
