### PR TITLE
fix: add tiff url to error messages TDE-961

### DIFF
--- a/src/commands/path/path.generate.ts
+++ b/src/commands/path/path.generate.ts
@@ -176,7 +176,7 @@ export async function loadFirstTiff(source: string, collection: StacCollection):
 export function extractGsd(tiff: CogTiff): number {
   const gsd = tiff.images[0]?.resolution[0];
   if (gsd == null) {
-    throw new Error(`Missing resolution tiff tag`);
+    throw new Error(`Missing resolution tiff tag: ${tiff.source.url}`);
   }
   return gsd;
 }
@@ -184,9 +184,9 @@ export function extractGsd(tiff: CogTiff): number {
 export function extractEpsg(tiff: CogTiff): number {
   const epsg = tiff.images[0]?.epsg;
   if (epsg == null) {
-    throw new Error(`Missing epsg tiff tag`);
+    throw new Error(`Missing epsg tiff tag: ${tiff.source.url}`);
   } else if (!Epsg.Codes.has(epsg)) {
-    throw new Error(`Invalid EPSG code: ${epsg}`);
+    throw new Error(`Invalid EPSG code: ${epsg} on tiff: ${tiff.source.url}`);
   }
   return epsg;
 }


### PR DESCRIPTION
#### Motivation

This change provides the user with more information if an error were to occur.

#### Modification

`tiff.source.url` added to errror messages.
Resolves a nit in this [PR](https://github.com/linz/argo-tasks/pull/828)

#### Checklist

_If not applicable, provide explanation of why._

~~- [ ] Tests updated~~ - n/a
~~- [ ] Docs updated~~ - n/a
- [x] Issue linked in Title
