### PR TITLE
fix: update target path naming hierarchy TDE-955

### DIFF
--- a/src/commands/path/__test__/generate.path.test.ts
+++ b/src/commands/path/__test__/generate.path.test.ts
@@ -40,10 +40,7 @@ describe('GeneratePathImagery', () => {
       gsd: 0.25,
       epsg: 2193,
     };
-    assert.equal(
-      generatePath(metadata),
-      's3://nz-imagery/hawkes-bay/hawkes-bay-north-island-weather-event_2023_0.25m/rgb/2193/',
-    );
+    assert.equal(generatePath(metadata), 's3://nz-imagery/hawkes-bay/north-island-weather-event_2023_0.25m/rgb/2193/');
   });
   it('Should match - no optional metadata', () => {
     const metadata: PathMetadata = {
@@ -94,9 +91,9 @@ describe('GeneratePathSatelliteImagery', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-imagery',
       category: 'satellite-imagery',
-      geographicDescription: 'North Island',
+      geographicDescription: undefined,
       region: 'new-zealand',
-      event: 'Cyclone Gabrielle',
+      event: 'North Island Cyclone Gabrielle',
       date: '2023',
       gsd: 0.5,
       epsg: 2193,
@@ -134,7 +131,7 @@ describe('formatName', () => {
     assert.equal(formatName('hawkes-bay', 'Napier', ''), 'napier');
   });
   it('Should match - region & event', () => {
-    assert.equal(formatName('canterbury', '', 'Christchurch Earthquake'), 'canterbury-christchurch-earthquake');
+    assert.equal(formatName('canterbury', '', 'Christchurch Earthquake'), 'christchurch-earthquake');
   });
 });
 
@@ -190,12 +187,11 @@ describe('geographicDescription', async () => {
     const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
       './src/commands/path/__test__/sample.json',
     );
-    const gd = collection['linz:geographic_description'];
-    assert.equal(gd, 'Palmerston North');
+    assert.equal(collection['linz:geographic_description'], 'Palmerston North');
     const metadata: PathMetadata = {
       targetBucketName: 'bucket',
       category: 'urban-aerial-photos',
-      geographicDescription: gd,
+      geographicDescription: collection['linz:geographic_description'],
       region: 'manawatu-whanganui',
       event: '',
       date: '2020',
@@ -240,7 +236,7 @@ describe('event', async () => {
       gsd: 0.05,
       epsg: 2193,
     };
-    assert.equal(generatePath(metadata), 's3://bucket/nelson/nelson-storm_2020_0.05m/rgb/2193/');
+    assert.equal(generatePath(metadata), 's3://bucket/nelson/storm_2020_0.05m/rgb/2193/');
   });
   it('Should return undefined - no event metadata', async () => {
     const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
@@ -273,16 +269,22 @@ describe('region', async () => {
 
 describe('formatDate', async () => {
   it('Should return date as single year', async () => {
-    const collection = await fsa.readJson<StacCollection>('./src/commands/path/__test__/sample.json');
+    const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
+      './src/commands/path/__test__/sample.json',
+    );
     assert.equal(formatDate(collection), '2022');
   });
   it('Should return date as two years', async () => {
-    const collection = await fsa.readJson<StacCollection>('./src/commands/path/__test__/sample.json');
+    const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
+      './src/commands/path/__test__/sample.json',
+    );
     collection.extent.temporal.interval[0] = ['2022-12-31T11:00:00Z', '2023-12-31T11:00:00Z'];
     assert.equal(formatDate(collection), '2022-2023');
   });
   it('Should fail - unable to retrieve date', async () => {
-    const collection = await fsa.readJson<StacCollection>('./src/commands/path/__test__/sample.json');
+    const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
+      './src/commands/path/__test__/sample.json',
+    );
     collection.extent.temporal.interval[0] = [null, null];
     assert.throws(() => {
       formatDate(collection), Error;

--- a/src/commands/path/__test__/generate.path.test.ts
+++ b/src/commands/path/__test__/generate.path.test.ts
@@ -22,7 +22,6 @@ describe('GeneratePathImagery', () => {
       category: 'urban-aerial-photos',
       geographicDescription: 'Napier',
       region: 'hawkes-bay',
-      event: undefined,
       date: '2017-2018',
       gsd: 0.05,
       epsg: 2193,
@@ -33,9 +32,8 @@ describe('GeneratePathImagery', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-imagery',
       category: 'rural-aerial-photos',
-      geographicDescription: undefined,
+      geographicDescription: 'North Island Weather Event',
       region: 'hawkes-bay',
-      event: 'North Island Weather Event',
       date: '2023',
       gsd: 0.25,
       epsg: 2193,
@@ -48,7 +46,6 @@ describe('GeneratePathImagery', () => {
       category: 'urban-aerial-photos',
       geographicDescription: undefined,
       region: 'auckland',
-      event: undefined,
       date: '2023',
       gsd: 0.3,
       epsg: 2193,
@@ -64,7 +61,6 @@ describe('GeneratePathElevation', () => {
       category: 'dem',
       geographicDescription: undefined,
       region: 'auckland',
-      event: undefined,
       date: '2023',
       gsd: 1,
       epsg: 2193,
@@ -77,7 +73,6 @@ describe('GeneratePathElevation', () => {
       category: 'dsm',
       geographicDescription: undefined,
       region: 'auckland',
-      event: undefined,
       date: '2023',
       gsd: 1,
       epsg: 2193,
@@ -91,9 +86,8 @@ describe('GeneratePathSatelliteImagery', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-imagery',
       category: 'satellite-imagery',
-      geographicDescription: undefined,
+      geographicDescription: 'North Island Cyclone Gabrielle',
       region: 'new-zealand',
-      event: 'North Island Cyclone Gabrielle',
       date: '2023',
       gsd: 0.5,
       epsg: 2193,
@@ -112,7 +106,6 @@ describe('GeneratePathHistoricImagery', () => {
       category: 'scanned-aerial-imagery',
       geographicDescription: undefined,
       region: 'wellington',
-      event: undefined,
       date: '1963',
       gsd: 0.5,
       epsg: 2193,
@@ -125,13 +118,13 @@ describe('GeneratePathHistoricImagery', () => {
 
 describe('formatName', () => {
   it('Should match - region', () => {
-    assert.equal(formatName('hawkes-bay', '', ''), 'hawkes-bay');
+    assert.equal(formatName('hawkes-bay', undefined), 'hawkes-bay');
   });
   it('Should match - region & geographic description', () => {
-    assert.equal(formatName('hawkes-bay', 'Napier', ''), 'napier');
+    assert.equal(formatName('hawkes-bay', 'Napier'), 'napier');
   });
   it('Should match - region & event', () => {
-    assert.equal(formatName('canterbury', '', 'Christchurch Earthquake'), 'christchurch-earthquake');
+    assert.equal(formatName('canterbury', 'Christchurch Earthquake'), 'christchurch-earthquake');
   });
 });
 
@@ -193,7 +186,6 @@ describe('geographicDescription', async () => {
       category: 'urban-aerial-photos',
       geographicDescription: collection['linz:geographic_description'],
       region: 'manawatu-whanganui',
-      event: '',
       date: '2020',
       gsd: 0.05,
       epsg: 2193,
@@ -211,50 +203,11 @@ describe('geographicDescription', async () => {
       category: 'urban-aerial-photos',
       geographicDescription: collection['linz:geographic_description'],
       region: 'manawatu-whanganui',
-      event: undefined,
       date: '2020',
       gsd: 0.05,
       epsg: 2193,
     };
     assert.equal(generatePath(metadata), 's3://bucket/manawatu-whanganui/manawatu-whanganui_2020_0.05m/rgb/2193/');
-  });
-});
-
-describe('event', async () => {
-  it('Should return event', async () => {
-    const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
-      './src/commands/path/__test__/sample.json',
-    );
-    assert.equal(collection['linz:event_name'], 'Storm');
-    const metadata: PathMetadata = {
-      targetBucketName: 'bucket',
-      category: 'urban-aerial-photos',
-      geographicDescription: undefined,
-      region: 'nelson',
-      event: collection['linz:event_name'],
-      date: '2020',
-      gsd: 0.05,
-      epsg: 2193,
-    };
-    assert.equal(generatePath(metadata), 's3://bucket/nelson/storm_2020_0.05m/rgb/2193/');
-  });
-  it('Should return undefined - no event metadata', async () => {
-    const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
-      './src/commands/path/__test__/sample.json',
-    );
-    delete collection['linz:event_name'];
-    assert.equal(collection['linz:event_name'], undefined);
-    const metadata: PathMetadata = {
-      targetBucketName: 'bucket',
-      category: 'urban-aerial-photos',
-      geographicDescription: undefined,
-      region: 'nelson',
-      event: collection['linz:event_name'],
-      date: '2020',
-      gsd: 0.05,
-      epsg: 2193,
-    };
-    assert.equal(generatePath(metadata), 's3://bucket/nelson/nelson_2020_0.05m/rgb/2193/');
   });
 });
 

--- a/src/commands/path/path.generate.ts
+++ b/src/commands/path/path.generate.ts
@@ -126,10 +126,13 @@ function formatBucketName(bucketName: string): string {
  * @returns {string}
  */
 export function formatName(region: string, geographicDescription?: string, event?: string): string {
-  if (geographicDescription) {
-    return slugify([geographicDescription, event].filter(Boolean).join('-'));
+  if (event) {
+    return slugify(event.replace(' ', '-'));
   }
-  return slugify([region, event].filter(Boolean).join('-'));
+  if (geographicDescription) {
+    return slugify(geographicDescription.replace(' ', '-'));
+  }
+  return slugify(region.replace(' ', '-'));
 }
 
 export function formatDate(collection: StacCollection): string {

--- a/src/commands/path/path.generate.ts
+++ b/src/commands/path/path.generate.ts
@@ -16,7 +16,6 @@ export interface PathMetadata {
   category: string;
   geographicDescription?: string;
   region: string;
-  event?: string;
   date: string;
   gsd: number;
   epsg: number;
@@ -70,7 +69,6 @@ export const commandGeneratePath = command({
       category: collection['linz:geospatial_category'],
       region: collection['linz:region'],
       geographicDescription: collection['linz:geographic_description'],
-      event: collection['linz:event_name'],
       date: formatDate(collection),
       gsd: extractGsd(tiff),
       epsg: extractEpsg(tiff),
@@ -94,7 +92,7 @@ export const commandGeneratePath = command({
  * @returns {string}
  */
 export function generatePath(metadata: PathMetadata): string {
-  const name = formatName(metadata.region, metadata.geographicDescription, metadata.event);
+  const name = formatName(metadata.region, metadata.geographicDescription);
   if (metadata.category === dataCategories.SCANNED_AERIAL_PHOTOS) {
     // nb: Historic Imagery is out of scope as survey number is not yet recorded in collection metadata
     throw new Error(`Automated target generation not implemented for historic imagery`);
@@ -122,17 +120,13 @@ function formatBucketName(bucketName: string): string {
  * @export
  * @param {string} region
  * @param {?string} [geographicDescription]
- * @param {?string} [event]
  * @returns {string}
  */
-export function formatName(region: string, geographicDescription?: string, event?: string): string {
-  if (event) {
-    return slugify(event.replace(' ', '-'));
-  }
+export function formatName(region: string, geographicDescription?: string): string {
   if (geographicDescription) {
-    return slugify(geographicDescription.replace(' ', '-'));
+    return slugify(geographicDescription);
   }
-  return slugify(region.replace(' ', '-'));
+  return slugify(region);
 }
 
 export function formatDate(collection: StacCollection): string {


### PR DESCRIPTION
#### Motivation

The target path name formatting is inconsistent with the final decisions in the naming.md
It is now expected that the event name will be included in the `geographic_description` field as well. 

Sometimes the event name includes the location (`Top of the South Floods`) and sometimes it does not (`Cyclone Gabrielle`) Therefore it is difficult to determine whether to merge the `event_name` with the `region`/`geographic_description`. 

It is also preferable to keep the `event_name` consistent across all imagery so that datasets can be filtered by events for example the Cyclone Gabrielle imagery in Hawkes Bay, Gisborne & the North Island should all have `event_name=Cyclone Gabrielle`.

##### examples:
inputs: `region=Hawke's Bay` `gd= Hawke's Bay Cyclone Gabrielle` `event_name=Cyclone Gabrielle`
paths: `s3://nz-imagery/hawkes-bay/hawkes-bay-cyclone-gabrielle_2023_0.1m/`

inputs: `region=Nelson` `gd= Top of the South Floods` `event_name=Top of the South Floods`
paths: `s3://nz-imagery/nelson/top-of-the-south-floods_2023_0.1m/`

inputs: `region=Auckland`
paths: `s3://nz-imagery/auckland/auckland_2023_0.1m/`

inputs: `region=Wellington` `gd=Upper Hutt`
paths: `s3://nz-imagery/wellington/upper-hutt_2023_0.1m/`

#### Modification

name portion of the target path changed from:
```
if geographic_descr return geographic_descr-event?
else return region-event?
```
to
```
if geographic_descr return geographic_descr
return region
```


#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
~~- [ ] Docs updated~~ - n/a
- [x] Issue linked in Title
