### PR TITLE
fix: interim fix for Rakiura Stewart Island tiles TDE-1015

### DIFF
--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -14,7 +14,7 @@ import { CommandListArgs } from '../list/list.js';
 
 const SHEET_MIN_X = MapSheet.origin.x + 4 * MapSheet.width; // The minimum x coordinate of a valid sheet / tile
 const SHEET_MAX_X = MapSheet.origin.x + 46 * MapSheet.width; // The maximum x coordinate of a valid sheet / tile
-const SHEET_MIN_Y = MapSheet.origin.y - 41 * MapSheet.height; // The minimum y coordinate of a valid sheet / tile
+const SHEET_MIN_Y = MapSheet.origin.y - 42 * MapSheet.height; // The minimum y coordinate of a valid sheet / tile
 const SHEET_MAX_Y = MapSheet.origin.y; // The maximum y coordinate of a valid sheet / tile
 
 export function isTiff(x: string): boolean {


### PR DESCRIPTION
#### Motivation

Allow processing of the bottom row of map sheet tiles, pending refactoring and more robust mapsheet validation. This code will be removed when the mapsheet validation is updated.

#### Modification

There was a miscalculation that caused the lowest mapsheet row to be invalidated.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [X] Issue linked in Title
