### PR TITLE
fix: do not validate mapsheets against invalid ranges

### DIFF
--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -49,14 +49,31 @@ describe('getTileName', () => {
     assert.equal(convertTileName('AT24_50000_0101', 50000), 'AT24');
     assert.equal(convertTileName('AT25_50000_0101', 50000), 'AT25');
     assert.equal(convertTileName('CK08_50000_0101', 50000), 'CK08');
+    assert.equal(convertTileName('CK08_50000_0101', 50000), 'CK08');
   });
 
   for (const sheet of MapSheetData) {
-    it('should get the 1:50k, 1:10k, 1:5k and 1:1k for ' + sheet.code, () => {
+    it('should get the top left 1:50k, 1:10k, 1:5k and 1:1k 1:500 for ' + sheet.code, () => {
+      // getTileName
       assert.equal(getTileName(sheet.origin.x, sheet.origin.y, 50000), sheet.code);
       assert.equal(getTileName(sheet.origin.x, sheet.origin.y, 10000), sheet.code + '_10000_0101');
       assert.equal(getTileName(sheet.origin.x, sheet.origin.y, 5000), sheet.code + '_5000_0101');
       assert.equal(getTileName(sheet.origin.x, sheet.origin.y, 1000), sheet.code + '_1000_0101');
+      assert.equal(getTileName(sheet.origin.x, sheet.origin.y, 500), sheet.code + '_500_001001');
+    });
+
+    it('should get the bottom right 1:50k, 1:10k, 1:5k, 1:1k for ' + sheet.code, () => {
+      // for each scale calculate the bottom right tile then find the mid point of it
+      // then look up the tile name from the midpoint and ensure it is the same
+      for (const scale of [10_000, 5_000, 1_000, 500] as const) {
+        const tileCount = 50_000 / scale;
+        const tileName = `${tileCount - 1}`.padStart(scale === 500 ? 3 : 2, '0');
+        const sheetName = `${sheet.code}_${scale}_${tileName}${tileName}`;
+        const ret = MapSheet.getMapTileIndex(sheetName)!;
+        const midPointX = ret.origin.x + ret.width / 2;
+        const midPointY = ret.origin.y - ret.height / 2;
+        assert.equal(getTileName(midPointX, midPointY, scale), sheetName);
+      }
     });
   }
 });

--- a/src/utils/mapsheet.ts
+++ b/src/utils/mapsheet.ts
@@ -56,9 +56,9 @@ export type Bounds = Point & Size;
 const charA = 'A'.charCodeAt(0);
 const charS = 'S'.charCodeAt(0);
 
-export const mapSheetTileGridSize = 50_000;
-export const gridSizes = [mapSheetTileGridSize, 10_000, 5_000, 2_000, 1_000, 500] as const;
-export type GridSize = (typeof gridSizes)[number];
+export const MapSheetTileGridSize = 50_000;
+export const GridSizes = [MapSheetTileGridSize, 10_000, 5_000, 2_000, 1_000, 500] as const;
+export type GridSize = (typeof GridSizes)[number];
 
 /**
  * Topographic 1:50k map sheet calculator
@@ -82,15 +82,15 @@ export const MapSheet = {
   /** Width of Topo 1:50k map sheets (meters) */
   width: 24_000,
   /** Base scale Topo 1:50k map sheets (meters) */
-  scale: mapSheetTileGridSize,
+  scale: MapSheetTileGridSize,
   /** Map Sheets start at AS and end at CK */
   code: { start: 'AS', end: 'CK' },
   /** The top left point for where map sheets start from in NZTM2000 (EPSG:2193) */
   origin: { x: 988000, y: 6234000 },
-  gridSizeMax: mapSheetTileGridSize,
+  gridSizeMax: MapSheetTileGridSize,
   roundCorrection: 0.01,
   /** Allowed grid sizes, these should exist in the LINZ Data service (meters) */
-  gridSizes: gridSizes,
+  gridSizes: GridSizes,
 
   /**
    * Get the expected origin and map sheet information from a file name
@@ -107,7 +107,7 @@ export const MapSheet = {
     const sheetCode = match?.groups?.['sheetCode'];
     if (sheetCode == null) return null;
 
-    const gridSize = Number(match?.groups?.['gridSize'] ?? mapSheetTileGridSize);
+    const gridSize = Number(match?.groups?.['gridSize'] ?? MapSheetTileGridSize);
     const out: MapTileIndex = {
       mapSheet: sheetCode,
       gridSize: gridSize,
@@ -121,7 +121,7 @@ export const MapSheet = {
     };
 
     const mapSheetOffset = MapSheet.offset(sheetCode);
-    if (out.gridSize === mapSheetTileGridSize) {
+    if (out.gridSize === MapSheetTileGridSize) {
       out.y = mapSheetOffset.y;
       out.x = mapSheetOffset.x;
       out.origin = mapSheetOffset;


### PR DESCRIPTION
#### Motivation

the validation logic for mapsheets is currently giving incorrect results, this disables the validation logic until a better fix can be implemented.

#### Modification

removes the invalid magic numbers from mapsheet validation.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
