### PR TITLE
ci: avoid login to AWS if AWS_CI_ROLE not configured

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,6 +63,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
+        if: ${{env.AWS_CI_ROLE != ''}}
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
         with:
           aws-region: ap-southeast-2
@@ -70,6 +71,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CI_ROLE }}
 
       - name: Login to Amazon ECR
+        if: ${{env.AWS_CI_ROLE != ''}}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
 


### PR DESCRIPTION
#### Motivation

release-please.yml workflow should not try to login into AWS if AWS_CI_ROLE secret is not configured.

#### Modification

add a condition to login in AWS only if AWS_CI_ROLE exists

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
