### PR TITLE
revert: "refactor: Move default value up the stack TDE-1030 (#854)"

### DIFF
--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -10,7 +10,6 @@ import { logger, registerLogger } from '../log.js';
 import { isArgo } from '../utils/argo.js';
 
 export const config = option({
-  defaultValue: () => process.env['AWS_ROLE_CONFIG_PATH'],
   long: 'config',
   description: 'Location of role configuration file',
   type: optional(string),
@@ -32,7 +31,7 @@ export const forceOutput = flag({
 export function registerCli(cli: { name: string }, args: { verbose?: boolean; config?: string }): void {
   cleanArgs(args);
   registerLogger(args);
-  registerFileSystem(args.config);
+  registerFileSystem(args);
 
   logger.info({ package: CliInfo, cli: cli.name, args, isArgo: isArgo() }, 'Cli:Start');
 }

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -18,12 +18,13 @@ function splitConfig(x: string): string[] {
   return x.split(',');
 }
 
-export function registerFileSystem(config?: string): void {
+export function registerFileSystem(opts: { config?: string }): void {
   fsa.register('s3://', s3Fs);
 
-  if (config == null || config === '') return;
+  const configPath = opts.config ?? process.env['AWS_ROLE_CONFIG_PATH'];
+  if (configPath == null || configPath === '') return;
 
-  const paths = splitConfig(config);
+  const paths = splitConfig(configPath);
 
   for (const path of paths) s3Fs.credentials.registerConfig(path, fsa);
 }


### PR DESCRIPTION
This reverts commit 18576e6a246c46dd65f26dc2a24c5531af9703d6 which caused issues when copying files due to `registerCli` being invoked in multiple places.

