### PR TITLE
fix: CI missing environment variable for secret

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,6 +63,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
+        if: ${{env.AWS_CI_ROLE != ''}}
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
         with:
           aws-region: ap-southeast-2
@@ -70,6 +71,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CI_ROLE }}
 
       - name: Login to Amazon ECR
+        if: ${{env.AWS_CI_ROLE != ''}}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,9 @@ jobs:
     environment:
       name: prod
 
+    env:
+      AWS_CI_ROLE: ${{ secrets.AWS_CI_ROLE }}
+
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
#### Motivation

Environment variable for the secret `AWS_CI_ROLE` is not set.

#### Modification

Set the env for `AWS_CI_ROLE` secret.

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [ ] Issue linked in Title N/A
