### PR TITLE
fix: tileindex-validate errors should not been thrown asap TDE-1013

### DIFF
--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -221,14 +221,11 @@ export const commandTileIndexValidate = command({
 
     // Validate that all tiffs align to tile grid
     if (args.validate) {
-      let validationFailed = false;
+      let allValid = true;
       for (const tiff of locations) {
-        const valid = validateTiffAlignment(tiff);
-        if (valid === false) {
-          validationFailed = true;
-        }
+        allValid = allValid && validateTiffAlignment(tiff);
       }
-      if (validationFailed) throw new Error(`Tile alignment validation failed`);
+      if (!allValid) throw new Error(`Tile alignment validation failed`);
     }
 
     if (retileNeeded) throw new Error(`Duplicate files found, see output.geojson`);


### PR DESCRIPTION
#### Motivation

In order to have a better overview of the errors, errors should be collected and logged at the end rathen than thrown ASAP.

#### Modification

- Avoid throwing error as soon as they're detected
- Couple of refactors to simplify the code

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [x] Issue linked in Title
