### PR TITLE
fix: validate that all TIFF locations have been extracted TDE-1013

### DIFF
--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -101,6 +101,17 @@ describe('tiffLocation', () => {
     const location = await extractTiffLocations([TiffAy29], 1000);
     assert.equal(location[0]?.tileName, 'AS21_1000_0101');
   });
+
+  it('should fail if one location is not extracted', async () => {
+    const TiffAs21 = FakeCogTiff.fromTileName('AS21_1000_0101');
+    TiffAs21.images[0].origin[0] = 1492000;
+    TiffAs21.images[0].origin[1] = 6234000;
+    const TiffAy29 = FakeCogTiff.fromTileName('AY29_1000_0101');
+    TiffAy29.images[0].origin[0] = 1684000;
+    TiffAy29.images[0].origin[1] = 6018000;
+    TiffAy29.images[0].epsg = 0; // make the projection failing
+    await assert.rejects(extractTiffLocations([TiffAs21, TiffAy29], 1000));
+  });
 });
 
 describe('validate', () => {

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -331,7 +331,11 @@ export async function extractTiffLocations(
   );
 
   const output: TiffLocation[] = [];
-  for (const o of result) if (o) output.push(o);
+  for (const o of result) {
+    if (o === null) throw new Error('All TIFF locations have not been extracted.');
+    output.push(o);
+  }
+
   return output;
 }
 export function getSize(extent: [number, number, number, number]): Size {

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -114,6 +114,33 @@ export const GridSizeFromString: Type<string, GridSize> = {
   },
 };
 
+/**
+ *
+ * --validate // Validates all inputs align to output grid
+ * --retile // Creates a list of files that need to be retiled
+ *
+ *
+ * input: 1:1000
+ * scale: 1:1000
+ * // --retile=false --validate=true
+ * // Validate the top left points of every input align to the 1:1000 grid and no duplicates
+ *
+ * input: 1:1000
+ * scale: 1:1000
+ * // --retile=true --validate=true
+ * // Merges duplicate tiffs together the top left points of every input align to the 1:1000 grid and no duplicates
+ *
+ * input: 1:1000
+ * scale: 1:5000, 1:10_000
+ * // --retile=true --validate=false
+ * // create a re-tiling output of {tileName, input: string[] }
+ *
+ * -- Not handled (yet!)
+ * input: 1:10_000
+ * scale: 1:1000
+ * // create a re-tiling output of  1 input tiff = 100x {tileName, input: string}[]
+ *
+ */
 export const commandTileIndexValidate = command({
   name: 'tileindex-validate',
   description: 'List input files and validate there are no duplicates.',
@@ -255,31 +282,12 @@ export interface TiffLocation {
 }
 
 /**
+ * Create a list of `TiffLocation` from a list of TIFFs (`CogTiff`) by extracting their bounding box and generated their tile name from their origin based on a provided `GridSize`.
  *
- * --validate // Validates all inputs align to output grid
- * --retile // Creates a list of files that need to be retiled
- *
- *
- * input: 1:1000
- * scale: 1:1000
- * // --retile=false --validate=true
- * // Validate the top left points of every input align to the 1:1000 grid and no duplicates
- *
- * input: 1:1000
- * scale: 1:1000
- * // --retile=true --validate=true
- * // Merges duplicate tiffs together the top left points of every input align to the 1:1000 grid and no duplicates
- *
- * input: 1:1000
- * scale: 1:5000, 1:10_000
- * // --retile=true --validate=false
- * // create a re-tiling output of {tileName, input: string[] }
- *
- * -- Not handled (yet!)
- * input: 1:10_000
- * scale: 1:1000
- * // create a re-tiling output of  1 input tiff = 100x {tileName, input: string}[]
- *
+ * @param tiffs
+ * @param gridSize
+ * @param forceSourceEpsg
+ * @returns {TiffLocation[]}
  */
 export async function extractTiffLocations(
   tiffs: CogTiff[],


### PR DESCRIPTION
#### Motivation

When all the TIFF locations are not extracted, the system should throw an error rather than only logging the errors.

#### Modification

Validate that all TIFF locations have been extracted before continuing the process.

#### Checklist

- [x] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
