### PR TITLE
fix: all tiff alignment should be validated TDE-1013

### DIFF
--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -245,7 +245,8 @@ export const commandTileIndexValidate = command({
     if (args.validate) {
       let allValid = true;
       for (const tiff of locations) {
-        allValid = allValid && validateTiffAlignment(tiff);
+        const currentValid = validateTiffAlignment(tiff);
+        allValid = allValid && currentValid;
       }
       if (!allValid) throw new Error(`Tile alignment validation failed`);
     }


### PR DESCRIPTION
#### Motivation

A regression that avoid validating all Tiff alignments has been introduced in https://github.com/linz/argo-tasks/pull/877 where the validateTiffAlignment() could not be called if `allValid` is false (due to short-circuited evaluation).

#### Modification

Store the result of each validation in a variable to make sure the function is called each time.

#### Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A
- [x] Issue linked in Title
