### PR TITLE
fix(basemaps): Fix the event category is not parsed and populated in the pull request. BM-982

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -8,7 +8,7 @@ import { StacCollection } from 'stac-ts';
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
 import { registerCli, verbose } from '../common.js';
-import { Category, MakeCogGithub, parseCategory } from './make.cog.github.js';
+import { Category, MakeCogGithub } from './make.cog.github.js';
 
 const validTargetBuckets: Set<string> = new Set(['linz-basemaps', 'linz-basemaps-staging']);
 const validSourceBuckets: Set<string> = new Set(['nz-imagery', 'linz-imagery']);
@@ -102,7 +102,7 @@ export const basemapsCreatePullRequest = command({
   async handler(args) {
     registerCli(this, args);
     const target = args.target;
-    const category = args.category ? parseCategory(args.category) : Category.Other;
+    const category = args.category ?? Category.Other;
     let targets: string[];
     try {
       targets = JSON.parse(target);

--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -35,16 +35,6 @@ export const DefaultCategorySetting: Record<Category, CategorySetting> = {
   [Category.Event]: {},
 };
 
-export function parseCategory(category: string): Category {
-  const c = category.toLocaleLowerCase();
-  if (c.includes('urban')) return Category.Urban;
-  else if (c.includes('rural')) return Category.Rural;
-  else if (c.includes('satellite')) return Category.Satellite;
-  else if (c.includes('event')) return Category.Event;
-  else if (c.includes('scanned')) return Category.Scanned;
-  else return Category.Other;
-}
-
 const botEmail = 'basemaps@linz.govt.nz';
 const ConfigPrettierFormat = Object.assign({}, DEFAULT_PRETTIER_FORMAT, { printWidth: 200 });
 

--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -40,6 +40,8 @@ export function parseCategory(category: string): Category {
   if (c.includes('urban')) return Category.Urban;
   else if (c.includes('rural')) return Category.Rural;
   else if (c.includes('satellite')) return Category.Satellite;
+  else if (c.includes('event')) return Category.Event;
+  else if (c.includes('scanned')) return Category.Scanned;
   else return Category.Other;
 }
 


### PR DESCRIPTION
#### Motivation

The `Event` category are populated as `New Aerial Photos` when creating pull request.

#### Modification

- the `parseCategory` not parsing the `event` and `scanned` category. Just added them to fix.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
