### PR TITLE
feat: Set max attempts for S3 client TDE-1092

### DIFF
--- a/src/utils/s3.ts
+++ b/src/utils/s3.ts
@@ -1,0 +1,16 @@
+import { S3 } from '@aws-sdk/client-s3';
+
+export async function getS3ObjectAsJson<T>(bucket: string, collectionPath: string, s3: S3): Promise<T> {
+  return JSON.parse(
+    await s3
+      .getObject({
+        Bucket: bucket,
+        Key: collectionPath,
+      })
+      .then((value) => value.Body!.toString()),
+  ) as T;
+}
+
+export function s3Client(): S3 {
+  return new S3([{ maxAttempts: 3 }]);
+}


### PR DESCRIPTION
#### Motivation

Work around flakiness in AWS by retrying operations which fail regularly at scale.

#### Modification

Use AWS SDK directly instead of via chunkd, affording full control of the configuration.

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
