### PR TITLE
fix: Use Pacific/Auckland time zone for collection years TDE-1066

### DIFF
--- a/src/commands/path/__test__/generate.path.test.ts
+++ b/src/commands/path/__test__/generate.path.test.ts
@@ -225,14 +225,21 @@ describe('formatDate', async () => {
     const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
       './src/commands/path/__test__/sample.json',
     );
-    assert.equal(formatDate(collection), '2022');
+    assert.equal(formatDate(collection), '2023');
   });
   it('Should return date as two years', async () => {
     const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
       './src/commands/path/__test__/sample.json',
     );
-    collection.extent.temporal.interval[0] = ['2022-12-31T11:00:00Z', '2023-12-31T11:00:00Z'];
+    collection.extent.temporal.interval[0] = ['2022-06-01T11:00:00Z', '2023-06-01T11:00:00Z'];
     assert.equal(formatDate(collection), '2022-2023');
+  });
+  it('Should use Pacific/Auckland time zone', async () => {
+    const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(
+      './src/commands/path/__test__/sample.json',
+    );
+    collection.extent.temporal.interval[0] = ['2012-12-31T11:00:00Z', '2014-12-30T11:00:00Z'];
+    assert.equal(formatDate(collection), '2013-2014');
   });
   it('Should fail - unable to retrieve date', async () => {
     const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(

--- a/src/commands/path/path.generate.ts
+++ b/src/commands/path/path.generate.ts
@@ -131,8 +131,8 @@ export function formatName(region: string, geographicDescription?: string): stri
 
 export function formatDate(collection: StacCollection): string {
   const interval = collection.extent?.temporal?.interval?.[0];
-  const startYear = interval[0]?.slice(0, 4);
-  const endYear = interval[1]?.slice(0, 4);
+  const startYear = getPacificAucklandYear(interval[0]);
+  const endYear = getPacificAucklandYear(interval[1]);
 
   if (startYear == null || endYear == null) {
     throw new Error(`Missing datetime in interval: ${interval}`);
@@ -141,6 +141,21 @@ export function formatDate(collection: StacCollection): string {
     return startYear;
   }
   return `${startYear}-${endYear}`;
+}
+
+function getPacificAucklandYear(dateString: string | null): string | undefined {
+  if (dateString != null) {
+    /**
+     * We can't convert the time zone of a `Date` directly, but instead have to produce a localised date/time string.
+     * We arbitrarily convert to the New Zealand English format (For example, '2/04/2024, 11:27:30 am'), since it
+     * doesn't seem to be possible to convert directly to a more easily parsed format like ISO 8601 or RFC 3339.
+     */
+    const pacificAucklandDateTimeString = new Date(dateString).toLocaleString('en-NZ', {
+      timeZone: 'Pacific/Auckland',
+    });
+    return pacificAucklandDateTimeString.split(/[,/]/, 4)[2];
+  }
+  return undefined;
 }
 
 /*

--- a/src/commands/path/path.generate.ts
+++ b/src/commands/path/path.generate.ts
@@ -143,19 +143,27 @@ export function formatDate(collection: StacCollection): string {
   return `${startYear}-${endYear}`;
 }
 
-function getPacificAucklandYear(dateString: string | null): string | undefined {
-  if (dateString != null) {
-    /**
-     * We can't convert the time zone of a `Date` directly, but instead have to produce a localised date/time string.
-     * We arbitrarily convert to the New Zealand English format (For example, '2/04/2024, 11:27:30 am'), since it
-     * doesn't seem to be possible to convert directly to a more easily parsed format like ISO 8601 or RFC 3339.
-     */
-    const pacificAucklandDateTimeString = new Date(dateString).toLocaleString('en-NZ', {
-      timeZone: 'Pacific/Auckland',
-    });
-    return pacificAucklandDateTimeString.split(/[,/]/, 4)[2];
+/**
+ * Convert time zone-aware date/time string to Pacific/Auckland time zone string
+ *
+ * We can't convert the time zone of a `Date` directly, but instead have to produce a localised
+ * date/time string. We arbitrarily convert to the New Zealand English format (For example,
+ * '2/04/2024, 11:27:30 am'), since it doesn't seem to be possible to convert directly to a more
+ * easily parsed format like ISO 8601 or RFC 3339.
+ *
+ * @param {string | null} dateTimeString Optional date/time string which can be parsed by the `Date` constructor
+ * @returns {string | undefined} Localised date/time string
+ *
+ */
+function getPacificAucklandYear(dateTimeString: string | null): string | undefined {
+  if (dateTimeString == null) {
+    return undefined;
   }
-  return undefined;
+
+  const pacificAucklandDateTimeString = new Date(dateTimeString).toLocaleString('en-NZ', {
+    timeZone: 'Pacific/Auckland',
+  });
+  return pacificAucklandDateTimeString.split(/[,/]/, 4)[2];
 }
 
 /*


### PR DESCRIPTION
#### Motivation

The original code used the original UTC datetimes in the STAC collection to work out the start and end years. But we want to use the local start and end years.

#### Modification

Localise datetime string before extracting the year.

#### Checklist

- [x] Tests updated
- [ ] Docs updated (N/A)
- [x] Issue linked in Title
