### PR TITLE
feat: EAI_AGAIN middleware TDE-1114

### DIFF
--- a/src/__test__/eai_againRetry.test.ts
+++ b/src/__test__/eai_againRetry.test.ts
@@ -26,19 +26,19 @@ describe('eai_againRetryMiddleware', () => {
   });
   it('should run next once if it succeeds', () => {
     const fakeNext = fakeNextBuilder(0);
-    eaiAgainBuilder((attempt: number) => attempt * 0)(fakeNext, {})({ input: {}, request: {} });
+    eaiAgainBuilder(() => 0)(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 1);
   });
 
   it('should try three times when getting EAI_AGAIN errors', async () => {
     const fakeNext = fakeNextBuilder(2);
-    await eaiAgainBuilder((attempt: number) => attempt * 0)(fakeNext, {})({ input: {}, request: {} });
+    await eaiAgainBuilder(() => 0)(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 3);
   });
 
   it('should throw error if next fails three times', () => {
     const fakeNext = fakeNextBuilder(3);
-    assert.rejects(eaiAgainBuilder((attempt: number) => attempt * 0)(fakeNext, {})({ input: {}, request: {} }), {
+    assert.rejects(eaiAgainBuilder(() => 0)(fakeNext, {})({ input: {}, request: {} }), {
       message: 'EAI_AGAIN maximum tries (3) exceeded',
     });
   });

--- a/src/__test__/eai_againRetry.test.ts
+++ b/src/__test__/eai_againRetry.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, it } from 'node:test';
 
 import { BuildHandler, MetadataBearer } from '@smithy/types';
 
-import { eaiAgain } from '../fs.register.js';
+import { eaiAgainBuilder } from '../fs.register.js';
 
 let callCount = 0;
 
@@ -26,19 +26,19 @@ describe('eai_againRetryMiddleware', () => {
   });
   it('should run next once if it succeeds', () => {
     const fakeNext = buildFakeNext(0);
-    eaiAgain(fakeNext, {})({ input: {}, request: {} });
+    eaiAgainBuilder(0)(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 1);
   });
 
   it('should try three times when getting EAI_AGAIN errors', async () => {
     const fakeNext = buildFakeNext(2);
-    await eaiAgain(fakeNext, {})({ input: {}, request: {} });
+    await eaiAgainBuilder(0)(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 3);
   });
 
   it('should throw error if next fails three times', () => {
     const fakeNext = buildFakeNext(3);
-    assert.rejects(eaiAgain(fakeNext, {})({ input: {}, request: {} }), {
+    assert.rejects(eaiAgainBuilder(0)(fakeNext, {})({ input: {}, request: {} }), {
       message: 'EAI_AGAIN maximum tries (3) exceeded',
     });
   });

--- a/src/__test__/eai_againRetry.test.ts
+++ b/src/__test__/eai_againRetry.test.ts
@@ -7,7 +7,7 @@ import { eaiAgainBuilder } from '../fs.register.js';
 
 let callCount = 0;
 
-function buildFakeNext(failCount: number): BuildHandler<object, MetadataBearer> {
+function fakeNextBuilder(failCount: number): BuildHandler<object, MetadataBearer> {
   const fakeNext: BuildHandler<object, MetadataBearer> = () => {
     // fail twice and then succeed
     callCount += 1;
@@ -25,19 +25,19 @@ describe('eai_againRetryMiddleware', () => {
     callCount = 0;
   });
   it('should run next once if it succeeds', () => {
-    const fakeNext = buildFakeNext(0);
+    const fakeNext = fakeNextBuilder(0);
     eaiAgainBuilder(0)(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 1);
   });
 
   it('should try three times when getting EAI_AGAIN errors', async () => {
-    const fakeNext = buildFakeNext(2);
+    const fakeNext = fakeNextBuilder(2);
     await eaiAgainBuilder(0)(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 3);
   });
 
   it('should throw error if next fails three times', () => {
-    const fakeNext = buildFakeNext(3);
+    const fakeNext = fakeNextBuilder(3);
     assert.rejects(eaiAgainBuilder(0)(fakeNext, {})({ input: {}, request: {} }), {
       message: 'EAI_AGAIN maximum tries (3) exceeded',
     });

--- a/src/__test__/eai_againRetry.test.ts
+++ b/src/__test__/eai_againRetry.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { BuildHandler, MetadataBearer } from '@smithy/types';
+
+import { eai } from '../fs.register.js';
+
+let callCount = 0;
+
+function buildFakeNext(failCount: number): BuildHandler<object, MetadataBearer> {
+  const fakeNext: BuildHandler<object, MetadataBearer> = () => {
+    // fail twice and then succeed
+    callCount += 1;
+    if (callCount < 1 + failCount) {
+      return Promise.reject({ code: 'EAI_AGAIN' });
+    } else {
+      return Promise.resolve({ output: { $metadata: {} }, response: {} });
+    }
+  };
+  return fakeNext;
+}
+
+describe('eai_againRetryMiddleware', () => {
+  beforeEach(() => {
+    callCount = 0;
+  });
+  it('should run next once if it succeeds', () => {
+    const fakeNext = buildFakeNext(0);
+    eai(fakeNext, {})({ input: {}, request: {} });
+    assert.equal(callCount, 1);
+  });
+
+  it('should try three times when getting EAI_AGAIN errors', async () => {
+    const fakeNext = buildFakeNext(2);
+    await eai(fakeNext, {})({ input: {}, request: {} });
+    assert.equal(callCount, 3);
+  });
+
+  it('should throw error if next fails three times', () => {
+    const fakeNext = buildFakeNext(3);
+    assert.rejects(eai(fakeNext, {})({ input: {}, request: {} }), { message: 'EAI_AGAIN maximum tries (3) exceeded' });
+  });
+});

--- a/src/__test__/eai_againRetry.test.ts
+++ b/src/__test__/eai_againRetry.test.ts
@@ -9,7 +9,7 @@ let callCount = 0;
 
 function fakeNextBuilder(failCount: number): BuildHandler<object, MetadataBearer> {
   const fakeNext: BuildHandler<object, MetadataBearer> = () => {
-    // fail twice and then succeed
+    // fail a specified number of times and then succeed
     callCount += 1;
     if (callCount < 1 + failCount) {
       return Promise.reject({ code: 'EAI_AGAIN' });

--- a/src/__test__/eai_againRetry.test.ts
+++ b/src/__test__/eai_againRetry.test.ts
@@ -26,19 +26,19 @@ describe('eai_againRetryMiddleware', () => {
   });
   it('should run next once if it succeeds', () => {
     const fakeNext = fakeNextBuilder(0);
-    eaiAgainBuilder(0)(fakeNext, {})({ input: {}, request: {} });
+    eaiAgainBuilder((attempt: number) => attempt * 0)(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 1);
   });
 
   it('should try three times when getting EAI_AGAIN errors', async () => {
     const fakeNext = fakeNextBuilder(2);
-    await eaiAgainBuilder(0)(fakeNext, {})({ input: {}, request: {} });
+    await eaiAgainBuilder((attempt: number) => attempt * 0)(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 3);
   });
 
   it('should throw error if next fails three times', () => {
     const fakeNext = fakeNextBuilder(3);
-    assert.rejects(eaiAgainBuilder(0)(fakeNext, {})({ input: {}, request: {} }), {
+    assert.rejects(eaiAgainBuilder((attempt: number) => attempt * 0)(fakeNext, {})({ input: {}, request: {} }), {
       message: 'EAI_AGAIN maximum tries (3) exceeded',
     });
   });

--- a/src/__test__/eai_againRetry.test.ts
+++ b/src/__test__/eai_againRetry.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, it } from 'node:test';
 
 import { BuildHandler, MetadataBearer } from '@smithy/types';
 
-import { eai } from '../fs.register.js';
+import { eaiAgain } from '../fs.register.js';
 
 let callCount = 0;
 
@@ -26,18 +26,20 @@ describe('eai_againRetryMiddleware', () => {
   });
   it('should run next once if it succeeds', () => {
     const fakeNext = buildFakeNext(0);
-    eai(fakeNext, {})({ input: {}, request: {} });
+    eaiAgain(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 1);
   });
 
   it('should try three times when getting EAI_AGAIN errors', async () => {
     const fakeNext = buildFakeNext(2);
-    await eai(fakeNext, {})({ input: {}, request: {} });
+    await eaiAgain(fakeNext, {})({ input: {}, request: {} });
     assert.equal(callCount, 3);
   });
 
   it('should throw error if next fails three times', () => {
     const fakeNext = buildFakeNext(3);
-    assert.rejects(eai(fakeNext, {})({ input: {}, request: {} }), { message: 'EAI_AGAIN maximum tries (3) exceeded' });
+    assert.rejects(eaiAgain(fakeNext, {})({ input: {}, request: {} }), {
+      message: 'EAI_AGAIN maximum tries (3) exceeded',
+    });
   });
 });

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -38,6 +38,7 @@ export const fqdn: FinalizeRequestMiddleware<object, MetadataBearer> = (next) =>
 export function eaiAgainBuilder(timeout: (attempt: number) => number): BuildMiddleware<object, MetadataBearer> {
   const eaiAgain: BuildMiddleware<object, MetadataBearer> = (next) => {
     const maxTries = 3;
+    let totalDelay = 0;
     return async (args) => {
       for (let attempt = 1; attempt <= maxTries; attempt++) {
         try {
@@ -48,8 +49,8 @@ export function eaiAgainBuilder(timeout: (attempt: number) => number): BuildMidd
               throw error;
             }
             const delay = timeout(attempt);
-            logger.warn({ host: error.hostname, attempt, delay, totalDelay }, `eai_again:retry`);
             totalDelay += delay;
+            logger.warn({ host: error.hostname, attempt, delay, totalDelay }, `eai_again:retry`);
             await setTimeout(timeout(attempt));
           } else {
             throw error;

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -58,8 +58,8 @@ export function eaiAgainBuilder(timeout: number): BuildMiddleware<object, Metada
 
 const client = new S3Client();
 export const s3Fs = new FsAwsS3V3(client);
-client.middlewareStack.add(fqdn, { name: 'FQDN', step: 'finalizeRequest' });
 client.middlewareStack.add(eaiAgainBuilder(1000), { name: 'EAI_AGAIN', step: 'build' });
+client.middlewareStack.add(fqdn, { name: 'FQDN', step: 'finalizeRequest' });
 
 FsAwsS3.MaxListCount = 1000;
 s3Fs.credentials.onFileSystemCreated = (acc: AwsCredentialConfig, fs: FileSystem): void => {

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -65,7 +65,7 @@ export function eaiAgainBuilder(timeout: (attempt: number) => number): BuildMidd
 const client = new S3Client();
 export const s3Fs = new FsAwsS3V3(client);
 client.middlewareStack.add(
-  eaiAgainBuilder((attempt: number) => attempt * 1000),
+  eaiAgainBuilder((attempt: number) => 100 + attempt * 1000),
   { name: 'EAI_AGAIN', step: 'build' },
 );
 client.middlewareStack.add(fqdn, { name: 'FQDN', step: 'finalizeRequest' });

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -35,7 +35,7 @@ export const fqdn: FinalizeRequestMiddleware<object, MetadataBearer> = (next) =>
 /**
  * AWS SDK middleware logic to retry after receiving an EAI_AGAIN error
  */
-export const eai: BuildMiddleware<object, MetadataBearer> = (next) => {
+export const eaiAgain: BuildMiddleware<object, MetadataBearer> = (next) => {
   const maxTries = 3;
   return async (args) => {
     for (let i = 0; i < maxTries; i++) {
@@ -56,7 +56,7 @@ export const eai: BuildMiddleware<object, MetadataBearer> = (next) => {
 const client = new S3Client();
 export const s3Fs = new FsAwsS3V3(client);
 client.middlewareStack.add(fqdn, { name: 'FQDN', step: 'finalizeRequest' });
-client.middlewareStack.add(eai, { name: 'EAI_AGAIN', step: 'build' });
+client.middlewareStack.add(eaiAgain, { name: 'EAI_AGAIN', step: 'build' });
 
 FsAwsS3.MaxListCount = 1000;
 s3Fs.credentials.onFileSystemCreated = (acc: AwsCredentialConfig, fs: FileSystem): void => {

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -33,7 +33,7 @@ export const fqdn: FinalizeRequestMiddleware<object, MetadataBearer> = (next) =>
 };
 
 /**
- * AWS SDK middleware logic to retry after receiving an EAI_AGAIN error
+ * AWS SDK middleware logic to try 3 times if receiving an EAI_AGAIN error
  */
 export function eaiAgainBuilder(timeout: number): BuildMiddleware<object, MetadataBearer> {
   const eaiAgain: BuildMiddleware<object, MetadataBearer> = (next) => {

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -47,7 +47,9 @@ export function eaiAgainBuilder(timeout: (attempt: number) => number): BuildMidd
             if (error.code !== 'EAI_AGAIN') {
               throw error;
             }
-            logger.warn({ host: error.hostname }, `eai_again retry #${attempt}`);
+            const delay = timeout(attempt);
+            logger.warn({ host: error.hostname, attempt, delay, totalDelay }, `eai_again:retry`);
+            totalDelay += delay;
             await setTimeout(timeout(attempt));
           } else {
             throw error;

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -1,4 +1,4 @@
-import { scheduler } from 'node:timers/promises';
+import { setTimeout } from 'node:timers/promises';
 
 import { S3Client } from '@aws-sdk/client-s3';
 import { FileSystem } from '@chunkd/core';
@@ -46,7 +46,7 @@ export const eai: BuildMiddleware<object, MetadataBearer> = (next) => {
           throw error;
         }
         logger.error('eai_again:retry:' + i);
-        await scheduler.wait(1000);
+        await setTimeout(1000);
       }
     }
     throw new Error(`EAI_AGAIN maximum tries (${maxTries}) exceeded`);

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -35,28 +35,31 @@ export const fqdn: FinalizeRequestMiddleware<object, MetadataBearer> = (next) =>
 /**
  * AWS SDK middleware logic to retry after receiving an EAI_AGAIN error
  */
-export const eaiAgain: BuildMiddleware<object, MetadataBearer> = (next) => {
-  const maxTries = 3;
-  return async (args) => {
-    for (let i = 0; i < maxTries; i++) {
-      try {
-        return await next(args);
-      } catch (error) {
-        if (error && typeof error === 'object' && 'code' in error && error.code !== 'EAI_AGAIN') {
-          throw error;
+export function eaiAgainBuilder(timeout: number): BuildMiddleware<object, MetadataBearer> {
+  const eaiAgain: BuildMiddleware<object, MetadataBearer> = (next) => {
+    const maxTries = 3;
+    return async (args) => {
+      for (let i = 0; i < maxTries; i++) {
+        try {
+          return await next(args);
+        } catch (error) {
+          if (error && typeof error === 'object' && 'code' in error && error.code !== 'EAI_AGAIN') {
+            throw error;
+          }
+          logger.error('eai_again:retry:' + i);
+          await setTimeout(timeout);
         }
-        logger.error('eai_again:retry:' + i);
-        await setTimeout(1000);
       }
-    }
-    throw new Error(`EAI_AGAIN maximum tries (${maxTries}) exceeded`);
+      throw new Error(`EAI_AGAIN maximum tries (${maxTries}) exceeded`);
+    };
   };
-};
+  return eaiAgain;
+}
 
 const client = new S3Client();
 export const s3Fs = new FsAwsS3V3(client);
 client.middlewareStack.add(fqdn, { name: 'FQDN', step: 'finalizeRequest' });
-client.middlewareStack.add(eaiAgain, { name: 'EAI_AGAIN', step: 'build' });
+client.middlewareStack.add(eaiAgainBuilder(1000), { name: 'EAI_AGAIN', step: 'build' });
 
 FsAwsS3.MaxListCount = 1000;
 s3Fs.credentials.onFileSystemCreated = (acc: AwsCredentialConfig, fs: FileSystem): void => {

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -35,11 +35,11 @@ export const fqdn: FinalizeRequestMiddleware<object, MetadataBearer> = (next) =>
 /**
  * AWS SDK middleware logic to try 3 times if receiving an EAI_AGAIN error
  */
-export function eaiAgainBuilder(timeout: Function): BuildMiddleware<object, MetadataBearer> {
+export function eaiAgainBuilder(timeout: (attempt: number) => number): BuildMiddleware<object, MetadataBearer> {
   const eaiAgain: BuildMiddleware<object, MetadataBearer> = (next) => {
     const maxTries = 3;
     return async (args) => {
-      for (let attempt = 0; attempt < maxTries; attempt++) {
+      for (let attempt = 1; attempt <= maxTries; attempt++) {
         try {
           return await next(args);
         } catch (error) {


### PR DESCRIPTION
#### Motivation

Retry workflows that fail due to EAI_AGAIN errors. 

#### Modification

Added an SDK middleware to try 3 times when receiving an `EAI_AGAIN` error. 

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [ ] Docs updated -n/a
- [x] Issue linked in Title
