### PR TITLE
feat(copy): check etag before skipping writes TDE-1172

### DIFF
--- a/src/commands/copy/copy-worker.ts
+++ b/src/commands/copy/copy-worker.ts
@@ -70,7 +70,16 @@ export const worker = new WorkerRpc<CopyContract>({
         if (source == null) return;
         if (source.size == null) return;
         if (target != null) {
-          if (source?.size === target.size && args.noClobber) {
+          const isEtagDifferent = source.eTag && target.eTag && source.eTag !== target.eTag;
+          if (source.size === target.size && args.noClobber) {
+            if (isEtagDifferent) {
+              log.error(
+                { target: target.path, source: source.path, sourceEtag: source.eTag, targetEtag: target.eTag },
+                'File:eTag:Overwrite',
+              );
+              throw new Error(`Cannot overwrite file: ${todo.target} source: ${todo.source} etag mismatch`);
+            }
+
             log.info({ path: todo.target, size: target.size }, 'File:Copy:Skipped');
             stats.skipped++;
             stats.skippedBytes += source.size;


### PR DESCRIPTION
#### Motivation

When copying tiff files, sometimes the header information can change without affecting the file size.

There needs to be a safer way to determine if the files are the same so they can be updated.

ETag is not perfect, as it depending on how the file is uploaded the ETag can vary, but since its the same process doingt he copy

#### Modification

If the file exists and is a `--no-clobber` operation validate that the ETags match.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
