### PR TITLE
feat(basemaps): Should skip creating pull request when exist instead of throwing errors. BM-1018

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -209,7 +209,7 @@ export class GithubApi {
         throw e;
       });
 
-    if (this.isOk(response?.status)) {
+    if (response != null && this.isOk(response.status)) {
       logger.info({ branch, url: response.data.html_url }, 'GitHub: Create Pull Request');
       return response.data.number;
     }

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -209,7 +209,7 @@ export class GithubApi {
         throw e;
       });
 
-    if (response != null && this.isOk(response.status)) {
+    if (this.isOk(response?.status)) {
       logger.info({ branch, url: response.data.html_url }, 'GitHub: Create Pull Request');
       return response.data.number;
     }

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -202,7 +202,7 @@ export class GithubApi {
         base: 'master',
       })
       .catch((e) => {
-        if (e?.status === 422 && e.message.toString().includes('A pull request already exists')) {
+        if (e?.status === 422 && String(e.message).includes('A pull request already exists')) {
           logger.info({ branch }, 'A pull request already exists for branch');
           return null;
         }


### PR DESCRIPTION
#### Motivation

Some of `create-pr` using the same branch names like the vector map etl, this might be cause the failure when a pull request exist for the branch. We should just skip the last step for creating pull when existing branch have a pull request opened. Because, the previous steps in create-pr commends already commit and updated the existing branch and PR. We can just skip pull request creation instead of failing. 

Example of [failure](https://argo.linzaccess.com/workflows/argo/cron-vector-etl-topographic-1713290400?tab=workflow&nodeId=cron-vector-etl-topographic-1713290400-2880775147&nodePanelView=summary&sidePanel=logs:cron-vector-etl-topographic-1713290400-2880775147:main&uid=99d03ed9-5aa8-49c5-95ba-236d21c40aba). 

#### Modification

- Add a catch at pull request creation API, to check the validation failure based on the message. https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28


#### Checklist

- [ ] Tests updated - no test, but locally tested.
- [ ] Docs updated - no doc
- [x] Issue linked in Title
