### PR TITLE
fix: only validate the tiffs are 8 bit if the preset is webp TDE-1151 TDE-895

### DIFF
--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -80,7 +80,7 @@ export function parseSize(size: string): number {
 }
 
 /** Limit fetches to 25 concurrently **/
-const TiffQueue = pLimit(25);
+export const TiffQueue = pLimit(25);
 
 /**
  * There is a minor difference between @chunkd/core and @cogeotiff/core


### PR DESCRIPTION
#### Motivation

Only webp presets require tiffs to be 8bit 3 or 4 band tiffs, when processing dems or LZW we do not need to validate against 8bit

#### Modification

Validate tiffs against a 8bit only when the preset is webp.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
