### PR TITLE
feat(basemaps): Titleize the vector map config name. BM-1017

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -7,6 +7,7 @@ import { StacCollection } from 'stac-ts';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
+import { titleizeVectorName } from '../../utils/bmc.utils.js';
 import { registerCli, verbose } from '../common.js';
 import { Category, MakeCogGithub } from './make.cog.github.js';
 
@@ -145,7 +146,7 @@ export const basemapsCreatePullRequest = command({
       for (const target of targets) {
         const info = await parseVectorTargetInfo(target);
         layer.name = info.name;
-        layer.title = info.title;
+        layer.title = titleizeVectorName(info.name);
         layer[info.epsg] = target;
       }
     } else {

--- a/src/utils/__test__/bmc.utils.test.ts
+++ b/src/utils/__test__/bmc.utils.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { titleizeVectorName } from '../bmc.utils.js';
+
+describe('titleizeVectorName', () => {
+  it('Should titleize Vector names', () => {
+    assert.equal(titleizeVectorName('topographic'), 'Topographic');
+    assert.equal(titleizeVectorName('53382-nz-roads-addressing'), '53382 NZ Roads Addressing');
+    assert.equal(
+      titleizeVectorName('51153-nz-coastlines-and-islands-polygons-topo-150k'),
+      '51153 NZ Coastlines And Islands Polygons Topo 150k',
+    );
+    assert.equal(titleizeVectorName('52168-niue-airport-polygons-topo-150k'), '52168 Niue Airport Polygons Topo 150k');
+  });
+
+  it('Should not uppercase NZ if not nz not between dashes', () => {
+    assert.equal(titleizeVectorName('00121-franz-josef-addressing'), '00121 Franz Josef Addressing');
+  });
+});

--- a/src/utils/bmc.utils.ts
+++ b/src/utils/bmc.utils.ts
@@ -1,0 +1,16 @@
+// Capitalize first letter of a string
+const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
+
+/**
+ * Vector image name usually is lower cases or the layer name from lds, we need titlized that for titles in config
+ * topographic -> Topographic
+ * 53382-nz-roads-addressing -> 53382 NZ Road Addressing
+ */
+export function titleizeVectorName(input: string): string {
+  const splits = input.split('-');
+  for (const [index, value] of splits.entries()) {
+    if (value === 'nz') splits[index] = value.toUpperCase();
+    else splits[index] = capitalize(value);
+  }
+  return splits.join(' ');
+}


### PR DESCRIPTION
#### Motivation

We want to titleize the vector titles from the name of lds layer.
topographic -> Topographic
53382-nz-roads-addressing -> 53382 NZ Road Addressing 

#### Modification

- Add a basemaps command util for titeize function which split all the dashes and uppercase for first letter.
- Check if nz present between the dashes we uppercase to NZ.

#### Checklist

- [x] Tests updated
- [ ] Docs updated - no doc
- [x] Issue linked in Title
