### PR TITLE
feat: stac validate links checksum TDE-1134

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ stac validate s3://linz-imagery-staging/test/stac-validate/collection.json
 stac validate --checksum --recursive s3://linz-imagery-staging/test/stac-validate/collection.json
 ```
 
-- Validate a the `file:checksum` of all links (only links, not assets) inside of a collection:
+- Validate the `file:checksum` of all links (only links, not assets) inside of a collection:
 
 ```bash
 stac validate --checksum-links --recursive s3://linz-imagery-staging/test/stac-validate/collection.json

--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ stac validate s3://linz-imagery-staging/test/stac-validate/collection.json
 stac validate --checksum --recursive s3://linz-imagery-staging/test/stac-validate/collection.json
 ```
 
+- Validate a the `file:checksum` of all links (only links, not assets) inside of a collection:
+
+```bash
+stac validate --checksum-links --recursive s3://linz-imagery-staging/test/stac-validate/collection.json
+```
+
 ### `tileindex-validate`
 
 Validate or create retiling information for a list of tiffs.

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -28,7 +28,10 @@ export const forceOutput = flag({
   defaultValueIsSerializable: true,
 });
 
-/** 1220 is the starting prefix for all sha256 multihashes */
+/** 1220 is the starting prefix for all sha256 multihashes
+ *  0x12 - ID of sha256 multi hash
+ *  0x20 - 32 bytes (256 bits) of data
+ */
 export const Sha256Prefix = '1220';
 
 export function registerCli(cli: { name: string }, args: { verbose?: boolean; config?: string }): void {

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -28,6 +28,9 @@ export const forceOutput = flag({
   defaultValueIsSerializable: true,
 });
 
+/** 1220 is the starting prefix for all sha256 multihashes */
+export const Sha256Prefix = '1220';
+
 export function registerCli(cli: { name: string }, args: { verbose?: boolean; config?: string }): void {
   cleanArgs(args);
   registerLogger(args);

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -28,12 +28,6 @@ export const forceOutput = flag({
   defaultValueIsSerializable: true,
 });
 
-/** 1220 is the starting prefix for all sha256 multihashes
- *  0x12 - ID of sha256 multi hash
- *  0x20 - 32 bytes (256 bits) of data
- */
-export const Sha256Prefix = '1220';
-
 export function registerCli(cli: { name: string }, args: { verbose?: boolean; config?: string }): void {
   cleanArgs(args);
   registerLogger(args);

--- a/src/commands/stac-catalog/stac.catalog.ts
+++ b/src/commands/stac-catalog/stac.catalog.ts
@@ -1,12 +1,12 @@
 import { fsa } from '@chunkd/fs';
 import { command, option, positional, string } from 'cmd-ts';
-import { createHash } from 'crypto';
 import { isAbsolute } from 'path';
 import * as st from 'stac-ts';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
-import { config, registerCli, Sha256Prefix, verbose } from '../common.js';
+import { hashString } from '../../utils/hash.js';
+import { config, registerCli, verbose } from '../common.js';
 
 /** is a path a URL */
 export function isUrl(path: string): boolean {
@@ -87,8 +87,7 @@ export async function createLinks(basePath: string, templateLinks: st.StacLink[]
       const relPath = makeRelative(basePath, coll);
       const buf = await fsa.read(coll);
       const collection = JSON.parse(buf.toString()) as st.StacCollection;
-      // Multihash header 0x12 - Sha256 0x20 - 32 bits of hex digest
-      const checksum = Sha256Prefix + createHash('sha256').update(buf).digest('hex');
+      const checksum = hashString(buf);
       const collLink: st.StacLink = {
         rel: 'child',
         href: fsa.join('./', relPath),

--- a/src/commands/stac-catalog/stac.catalog.ts
+++ b/src/commands/stac-catalog/stac.catalog.ts
@@ -5,7 +5,7 @@ import * as st from 'stac-ts';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
-import { hashString } from '../../utils/hash.js';
+import { hashBuffer } from '../../utils/hash.js';
 import { config, registerCli, verbose } from '../common.js';
 
 /** is a path a URL */
@@ -87,7 +87,7 @@ export async function createLinks(basePath: string, templateLinks: st.StacLink[]
       const relPath = makeRelative(basePath, coll);
       const buf = await fsa.read(coll);
       const collection = JSON.parse(buf.toString()) as st.StacCollection;
-      const checksum = hashString(buf);
+      const checksum = hashBuffer(buf);
       const collLink: st.StacLink = {
         rel: 'child',
         href: fsa.join('./', relPath),

--- a/src/commands/stac-catalog/stac.catalog.ts
+++ b/src/commands/stac-catalog/stac.catalog.ts
@@ -6,7 +6,7 @@ import * as st from 'stac-ts';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
-import { config, registerCli, verbose } from '../common.js';
+import { config, registerCli, Sha256Prefix, verbose } from '../common.js';
 
 /** is a path a URL */
 export function isUrl(path: string): boolean {
@@ -88,7 +88,7 @@ export async function createLinks(basePath: string, templateLinks: st.StacLink[]
       const buf = await fsa.read(coll);
       const collection = JSON.parse(buf.toString()) as st.StacCollection;
       // Multihash header 0x12 - Sha256 0x20 - 32 bits of hex digest
-      const checksum = '1220' + createHash('sha256').update(buf).digest('hex');
+      const checksum = Sha256Prefix + createHash('sha256').update(buf).digest('hex');
       const collLink: st.StacLink = {
         rel: 'child',
         href: fsa.join('./', relPath),

--- a/src/commands/stac-sync/__test__/stac.sync.test.ts
+++ b/src/commands/stac-sync/__test__/stac.sync.test.ts
@@ -5,6 +5,7 @@ import { fsa } from '@chunkd/fs';
 import { FsMemory } from '@chunkd/source-memory';
 import { createHash } from 'crypto';
 
+import { Sha256Prefix } from '../../common.js';
 import { HashKey, synchroniseFiles } from '../stac.sync.js';
 
 describe('stacSync', () => {
@@ -47,7 +48,7 @@ describe('stacSync', () => {
       JSON.stringify({ title: 'Wellington Collection', description: 'abcd' }),
     );
     const sourceData = await fsa.read('m://source/stac/wellington/collection.json');
-    const sourceHash = '1220' + createHash('sha256').update(sourceData).digest('hex');
+    const sourceHash = Sha256Prefix + createHash('sha256').update(sourceData).digest('hex');
     await fs.write(
       'm://destination/stac/wellington/collection.json',
       JSON.stringify({ title: 'Wellington Collection', description: 'abcd' }),

--- a/src/commands/stac-sync/__test__/stac.sync.test.ts
+++ b/src/commands/stac-sync/__test__/stac.sync.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, it } from 'node:test';
 import { fsa } from '@chunkd/fs';
 import { FsMemory } from '@chunkd/source-memory';
 
-import { hashString } from '../../../utils/hash.js';
+import { hashBuffer } from '../../../utils/hash.js';
 import { HashKey, synchroniseFiles } from '../stac.sync.js';
 
 describe('stacSync', () => {
@@ -47,7 +47,7 @@ describe('stacSync', () => {
       JSON.stringify({ title: 'Wellington Collection', description: 'abcd' }),
     );
     const sourceData = await fsa.read('m://source/stac/wellington/collection.json');
-    const sourceHash = hashString(sourceData);
+    const sourceHash = hashBuffer(sourceData);
     await fs.write(
       'm://destination/stac/wellington/collection.json',
       JSON.stringify({ title: 'Wellington Collection', description: 'abcd' }),

--- a/src/commands/stac-sync/__test__/stac.sync.test.ts
+++ b/src/commands/stac-sync/__test__/stac.sync.test.ts
@@ -3,9 +3,8 @@ import { beforeEach, describe, it } from 'node:test';
 
 import { fsa } from '@chunkd/fs';
 import { FsMemory } from '@chunkd/source-memory';
-import { createHash } from 'crypto';
 
-import { Sha256Prefix } from '../../common.js';
+import { hashString } from '../../../utils/hash.js';
 import { HashKey, synchroniseFiles } from '../stac.sync.js';
 
 describe('stacSync', () => {
@@ -48,7 +47,7 @@ describe('stacSync', () => {
       JSON.stringify({ title: 'Wellington Collection', description: 'abcd' }),
     );
     const sourceData = await fsa.read('m://source/stac/wellington/collection.json');
-    const sourceHash = Sha256Prefix + createHash('sha256').update(sourceData).digest('hex');
+    const sourceHash = hashString(sourceData);
     await fs.write(
       'm://destination/stac/wellington/collection.json',
       JSON.stringify({ title: 'Wellington Collection', description: 'abcd' }),

--- a/src/commands/stac-sync/stac.sync.ts
+++ b/src/commands/stac-sync/stac.sync.ts
@@ -1,11 +1,11 @@
 import { FileInfo } from '@chunkd/core';
 import { fsa } from '@chunkd/fs';
 import { command, positional, string, Type } from 'cmd-ts';
-import { createHash } from 'crypto';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
-import { config, registerCli, Sha256Prefix, verbose } from '../common.js';
+import { hashString } from '../../utils/hash.js';
+import { config, registerCli, verbose } from '../common.js';
 
 const S3Path: Type<string, URL> = {
   async from(str) {
@@ -72,7 +72,7 @@ export async function synchroniseFiles(sourcePath: string, destinationPath: URL)
 export async function uploadFileToS3(sourceFileInfo: FileInfo, path: URL): Promise<boolean> {
   const destinationHead = await fsa.head(path.href);
   const sourceData = await fsa.read(sourceFileInfo.path);
-  const sourceHash = Sha256Prefix + createHash('sha256').update(sourceData).digest('hex');
+  const sourceHash = hashString(sourceData);
   if (destinationHead?.size === sourceFileInfo.size && sourceHash === destinationHead?.metadata?.[HashKey]) {
     return false;
   }

--- a/src/commands/stac-sync/stac.sync.ts
+++ b/src/commands/stac-sync/stac.sync.ts
@@ -5,7 +5,7 @@ import { createHash } from 'crypto';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
-import { config, registerCli, verbose } from '../common.js';
+import { config, registerCli, Sha256Prefix, verbose } from '../common.js';
 
 const S3Path: Type<string, URL> = {
   async from(str) {
@@ -72,7 +72,7 @@ export async function synchroniseFiles(sourcePath: string, destinationPath: URL)
 export async function uploadFileToS3(sourceFileInfo: FileInfo, path: URL): Promise<boolean> {
   const destinationHead = await fsa.head(path.href);
   const sourceData = await fsa.read(sourceFileInfo.path);
-  const sourceHash = '1220' + createHash('sha256').update(sourceData).digest('hex');
+  const sourceHash = Sha256Prefix + createHash('sha256').update(sourceData).digest('hex');
   if (destinationHead?.size === sourceFileInfo.size && sourceHash === destinationHead?.metadata?.[HashKey]) {
     return false;
   }

--- a/src/commands/stac-sync/stac.sync.ts
+++ b/src/commands/stac-sync/stac.sync.ts
@@ -4,7 +4,7 @@ import { command, positional, string, Type } from 'cmd-ts';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
-import { hashString } from '../../utils/hash.js';
+import { hashBuffer } from '../../utils/hash.js';
 import { config, registerCli, verbose } from '../common.js';
 
 const S3Path: Type<string, URL> = {
@@ -72,7 +72,7 @@ export async function synchroniseFiles(sourcePath: string, destinationPath: URL)
 export async function uploadFileToS3(sourceFileInfo: FileInfo, path: URL): Promise<boolean> {
   const destinationHead = await fsa.head(path.href);
   const sourceData = await fsa.read(sourceFileInfo.path);
-  const sourceHash = hashString(sourceData);
+  const sourceHash = hashBuffer(sourceData);
   if (destinationHead?.size === sourceFileInfo.size && sourceHash === destinationHead?.metadata?.[HashKey]) {
     return false;
   }

--- a/src/commands/stac-validate/__test__/stac.validate.test.ts
+++ b/src/commands/stac-validate/__test__/stac.validate.test.ts
@@ -90,10 +90,7 @@ describe('stacValidate', function () {
         'file:checksum': '12206fd977db9b2afe87a9ceee48432881299a6aaf83d935fbbe83007660287f9c2e',
       };
 
-      const isValid = await validateStacChecksum(link, `${path}collection.json`, {
-        allowMissing: false,
-        allowUnknown: false,
-      });
+      const isValid = await validateStacChecksum(link, `${path}collection.json`, false);
       assert.equal(isValid, true);
     });
     it('should return the path of an asset with invalid checksum', async () => {
@@ -119,7 +116,6 @@ describe('stacValidate', function () {
       const errors = await validateAssets(stacItem, `${path}item.json`);
       assert.equal(errors.length, 1);
     });
-
     it('should validate a valid link checksum', async () => {
       await fsa.write(`${path}item.json`, Buffer.from(JSON.stringify({ test: true })));
       const stacCollection: st.StacCollection = {

--- a/src/commands/stac-validate/hash.worker.ts
+++ b/src/commands/stac-validate/hash.worker.ts
@@ -13,8 +13,6 @@ export async function hashStream(stream: Readable): Promise<string> {
   return new Promise((resolve, reject) => {
     const hash = createHash('sha256');
     stream.on('data', (chunk) => hash.update(chunk));
-    // 0x12 - ID of sha256 multi hash
-    // 0x20 - 32 bytes (256 bits) of data
     stream.on('end', () => resolve(Sha256Prefix + hash.digest('hex')));
     stream.on('error', reject);
   });

--- a/src/commands/stac-validate/hash.worker.ts
+++ b/src/commands/stac-validate/hash.worker.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'crypto';
 import { Readable } from 'stream';
 
+import { Sha256Prefix } from '../common.js';
+
 /**
  * Create a multihash from a stream
  *
@@ -13,7 +15,7 @@ export async function hashStream(stream: Readable): Promise<string> {
     stream.on('data', (chunk) => hash.update(chunk));
     // 0x12 - ID of sha256 multi hash
     // 0x20 - 32 bytes (256 bits) of data
-    stream.on('end', () => resolve(`1220` + hash.digest('hex')));
+    stream.on('end', () => resolve(Sha256Prefix + hash.digest('hex')));
     stream.on('error', reject);
   });
 }

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -258,7 +258,7 @@ export async function validateLinks(
  * @param stacObject a STAC Link or Asset
  * @param path path to the STAC location
  * @param allowMissing allow missing checksum to be valid
- * @returns
+ * @returns weither the checksum is valid or not
  */
 export async function validateStacChecksum(
   stacObject: st.StacLink | st.StacAsset,

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -243,6 +243,7 @@ export async function validateLinks(
   const linksFailures: string[] = [];
   for (const link of stacJson.links) {
     if (link.rel === 'self') continue;
+    // we `allowMissing` because some STAC links might not have a checksum yet (feature added later)
     const isChecksumValid = await validateStacChecksum(link, path, { allowMissing: true, allowUnknown: false });
     if (!isChecksumValid) {
       linksFailures.push(path);

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -9,7 +9,7 @@ import * as st from 'stac-ts';
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
 import { ConcurrentQueue } from '../../utils/concurrent.queue.js';
-import { config, registerCli, verbose } from '../common.js';
+import { config, registerCli, Sha256Prefix, verbose } from '../common.js';
 import { hashStream } from './hash.worker.js';
 
 export const commandStacValidate = command({
@@ -243,7 +243,7 @@ export async function validateLinks(
   const linksFailures: string[] = [];
   for (const link of stacJson.links) {
     if (link.rel === 'self') continue;
-    // we `allowMissing` because some STAC links might not have a checksum yet (feature added later)
+    // Allowing missing checksums as some STAC links might not have checksum
     const isChecksumValid = await validateStacChecksum(link, path, true);
     if (!isChecksumValid) {
       linksFailures.push(path);
@@ -273,8 +273,8 @@ export async function validateStacChecksum(
     logger.error({ source, checksum }, 'Validate:Checksum:Missing');
     return false;
   }
-  // 12-20 is the starting prefix for all sha256 multihashes
-  if (!checksum.startsWith('1220')) {
+
+  if (!checksum.startsWith(Sha256Prefix)) {
     logger.error({ source, checksum }, 'Validate:Checksum:Unknown');
     return false;
   }

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -9,8 +9,9 @@ import * as st from 'stac-ts';
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
 import { ConcurrentQueue } from '../../utils/concurrent.queue.js';
-import { config, registerCli, Sha256Prefix, verbose } from '../common.js';
-import { hashStream } from './hash.worker.js';
+import { hashStream } from '../../utils/hash.js';
+import { Sha256Prefix } from '../../utils/hash.js';
+import { config, registerCli, verbose } from '../common.js';
 
 export const commandStacValidate = command({
   name: 'stac-validate',

--- a/src/utils/__test__/hash.test.ts
+++ b/src/utils/__test__/hash.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert';
+import { Readable } from 'node:stream';
+import { describe, it } from 'node:test';
+
+import { hashStream, hashString } from '../hash.js';
+
+describe('hashString', () => {
+  it('should return the expecting digest', async () => {
+    const expectingDigest = '12209f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08';
+    const digest = hashString('test');
+    assert.equal(digest, expectingDigest);
+  });
+});
+
+describe('hashStream', () => {
+  it('should return the expecting digest', async () => {
+    const expectingDigest = '12209f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08';
+    const stream = Readable.from(['test']);
+    const digest = await hashStream(stream);
+    assert.equal(digest, expectingDigest);
+  });
+});

--- a/src/utils/__test__/hash.test.ts
+++ b/src/utils/__test__/hash.test.ts
@@ -2,12 +2,12 @@ import assert from 'node:assert';
 import { Readable } from 'node:stream';
 import { describe, it } from 'node:test';
 
-import { hashStream, hashString } from '../hash.js';
+import { hashBuffer, hashStream } from '../hash.js';
 
-describe('hashString', () => {
+describe('hashBuffer', () => {
   it('should return the expecting digest', async () => {
     const expectingDigest = '12209f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08';
-    const digest = hashString('test');
+    const digest = hashBuffer(Buffer.from('test'));
     assert.equal(digest, expectingDigest);
   });
 });

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -2,8 +2,10 @@ import { createHash } from 'crypto';
 import { Readable } from 'stream';
 
 /** 1220 is the starting prefix for all sha256 multihashes
- *  0x12 - ID of sha256 multi hash
- *  0x20 - 32 bytes (256 bits) of data
+ *  - 0x12 - ID of sha256 multi hash
+ *  - 0x20 - 32 bytes (256 bits) of data
+ *  
+ * https://multiformats.io/multihash/
  */
 export const Sha256Prefix = '1220';
 

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,7 +1,11 @@
 import { createHash } from 'crypto';
 import { Readable } from 'stream';
 
-import { Sha256Prefix } from '../common.js';
+/** 1220 is the starting prefix for all sha256 multihashes
+ *  0x12 - ID of sha256 multi hash
+ *  0x20 - 32 bytes (256 bits) of data
+ */
+export const Sha256Prefix = '1220';
 
 /**
  * Create a multihash from a stream
@@ -16,4 +20,14 @@ export async function hashStream(stream: Readable): Promise<string> {
     stream.on('end', () => resolve(Sha256Prefix + hash.digest('hex')));
     stream.on('error', reject);
   });
+}
+
+/**
+ * Create a multihash from a string or Buffer
+ *
+ * @param x a string or `Buffer`
+ * @returns sha256 multihash string of the string or `Buffer`
+ */
+export function hashString(x: Buffer | string): string {
+  return Sha256Prefix + createHash('sha256').update(x).digest('hex');
 }

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -4,8 +4,8 @@ import { Readable } from 'stream';
 /** 1220 is the starting prefix for all sha256 multihashes
  *  - 0x12 - ID of sha256 multi hash
  *  - 0x20 - 32 bytes (256 bits) of data
- *  
- * https://multiformats.io/multihash/
+ *
+ *  https://multiformats.io/multihash/
  */
 export const Sha256Prefix = '1220';
 

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -25,11 +25,11 @@ export async function hashStream(stream: Readable): Promise<string> {
 }
 
 /**
- * Create a multihash from a string or Buffer
+ * Create a multihash from a `Buffer`
  *
- * @param x a string or `Buffer`
- * @returns sha256 multihash string of the string or `Buffer`
+ * @param data a `Buffer`
+ * @returns sha256 multihash string of a `Buffer`
  */
-export function hashString(x: Buffer | string): string {
-  return Sha256Prefix + createHash('sha256').update(x).digest('hex');
+export function hashBuffer(data: Buffer): string {
+  return Sha256Prefix + createHash('sha256').update(data).digest('hex');
 }


### PR DESCRIPTION
#### Motivation

We need a way to validate all the STAC files quickly. Validating the `assets` takes a long time but validating just the JSON files (`links`) should be fast.

#### Modification

- Add the ability to the `stac validate` command to validate the link checksums
- Allow the `stac validate` command to validate only the `link` checksums (using `--checksum-links`) or both `asset` and `links` (`--checksum`)

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
