### PR TITLE
feat!: allow to validate asset checksums only TDE-1134

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,13 +255,19 @@ stac validate s3://linz-imagery-staging/test/stac-validate/collection.json
 - Validate a the `file:checksum` of all assets inside of a collection:
 
 ```bash
-stac validate --checksum --recursive s3://linz-imagery-staging/test/stac-validate/collection.json
+stac validate --checksum-assets --recursive s3://linz-imagery-staging/test/stac-validate/collection.json
 ```
 
-- Validate the `file:checksum` of all links (only links, not assets) inside of a collection:
+- Validate the `file:checksum` of all STAC links inside of a collection:
 
 ```bash
 stac validate --checksum-links --recursive s3://linz-imagery-staging/test/stac-validate/collection.json
+```
+
+- Validate the `file:checksum` of all assets and STAC links inside of a collection:
+
+```bash
+stac validate --checksum-assets --checksum-links --recursive s3://linz-imagery-staging/test/stac-validate/collection.json
 ```
 
 ### `tileindex-validate`

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -26,17 +26,17 @@ export const commandStacValidate = command({
       long: 'concurrency',
       description: 'Number of requests to run concurrently',
     }),
-    checksum: flag({
+    checksumAssets: flag({
       type: boolean,
       defaultValue: () => false,
-      long: 'checksum',
-      description: 'Validate the file:checksum if it exists',
+      long: 'checksum-assets',
+      description: 'Validate the file:checksum of each asset if it exists',
     }),
     checksumLinks: flag({
       type: boolean,
       defaultValue: () => false,
       long: 'checksum-links',
-      description: 'Validate the file:checksum of the links (STAC) if it exists',
+      description: 'Validate the file:checksum of each STAC link if it exists',
     }),
     recursive: flag({
       type: boolean,
@@ -160,14 +160,14 @@ export const commandStacValidate = command({
         }
       }
 
-      if (args.checksum) {
+      if (args.checksumAssets) {
         const assetFailures = await validateAssets(stacJson, path);
         if (assetFailures.length > 0) {
           isOk = false;
           failures.push(...assetFailures);
         }
       }
-      if (args.checksum || args.checksumLinks) {
+      if (args.checksumLinks) {
         const linksFailures = await validateLinks(stacJson, path);
         if (linksFailures.length > 0) {
           isOk = false;


### PR DESCRIPTION
#### Motivation

Current `--checksum` and `--checksum-links` flags overlap in the following case
`--checksum --checksum-links`, where `--checksum`  will validate both asset and link checksums so `--checksum-links` becomes pointless and confusing in that case.

#### Modification

Allow to validate the asset checksums only.
- To validate both asset and links checksums: `--checksum-assets --checksum-links`
- To validate asset checksums only: `--checksum-assets`
- To validate link checksums only: `--checksum-links`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated NA
- [x] Docs updated
- [x] Issue linked in Title
