### PR TITLE
fix(basemaps): Fix the collection.json path for the vector data.

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -80,7 +80,9 @@ async function parseVectorTargetInfo(target: string): Promise<{ name: string; ti
   assertValidBucket(bucket, validTargetBuckets);
 
   if (epsg == null || name == null) throw new Error(`Invalid target ${target} to parse the epsg and imagery name.`);
-  if (filename == null || !filename.endsWith('.tar.co')) throw new Error(`Invalid cotar filename for vector map ${filename}.`);
+  if (filename == null || !filename.endsWith('.tar.co')) {
+    throw new Error(`Invalid cotar filename for vector map ${filename}.`);
+  }
   if (epsg !== Epsg.Google) throw new Error(`Unsupported epsg code ${epsg.code} for vector map.`);
   // Try to get the title
   const collectionPath = target.replace(filename, 'collection.json');

--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -75,13 +75,15 @@ async function parseVectorTargetInfo(target: string): Promise<{ name: string; ti
   const splits = url.pathname.split('/');
   const epsg = Epsg.tryGet(Number(splits[2]));
   const name = splits[3];
+  const filename = splits.at(-1);
 
   assertValidBucket(bucket, validTargetBuckets);
 
   if (epsg == null || name == null) throw new Error(`Invalid target ${target} to parse the epsg and imagery name.`);
+  if (filename == null || !filename.endsWith('.tar.co')) throw new Error(`Invalid cotar filename for vector map ${filename}.`);
   if (epsg !== Epsg.Google) throw new Error(`Unsupported epsg code ${epsg.code} for vector map.`);
   // Try to get the title
-  const collectionPath = fsa.join(target, 'collection.json');
+  const collectionPath = target.replace(filename, 'collection.json');
   const collection = await fsa.readJson<StacCollection>(collectionPath);
   if (collection == null) throw new Error(`Failed to get target collection json from ${collectionPath}.`);
   const ldsLayers = collection.links.filter((f) => f.rel === 'lds:layer');


### PR DESCRIPTION
#### Motivation

[Argo Error log](https://argo.linzaccess.com/workflows/argo/cron-vector-etl-topographic-1715709600?tab=workflow&nodeId=cron-vector-etl-topographic-1715709600-1555051635&nodePanelView=containers&sidePanel=logs:cron-vector-etl-topographic-1715709600-1555051635:&uid=bbdff6e5-809d-4970-a41a-c0a5bd954423)

Vector target is different from raster with have the filename at the end. like `s3://linz-basemaps/vector/3857/topographic/01HXW47WJAM1KMZVN4QXR7SA70/topographic.tar.co` instead of `s3://linz-basemaps/vector/3857/topographic/01HXW47WJAM1KMZVN4QXR7SA70/`

So we need to replace the filename to `collection.json` instead of just adding it to the target.

#### Modification

- get the filename from the url and validate it as cotar file extension.
- prepare the correct collection.json path.

#### Checklist

- [ ] Tests updated - no test
- [ ] Docs updated - no doc
- [ ] Issue linked in Title - no ticket
