### PR TITLE
feat: allow paths to be split on ";" or "\n"

### DIFF
--- a/src/utils/__test__/chunk.test.ts
+++ b/src/utils/__test__/chunk.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { fsa } from '@chunkd/fs';
+import { FsMemory } from '@chunkd/source-memory';
+
+import { getFiles, splitPaths } from '../chunk.js';
+
+describe('splitPaths', () => {
+  it('should split on ;', () => {
+    assert.deepEqual(splitPaths(['a;b']), ['a', 'b']);
+  });
+  it('should split on \\n', () => {
+    assert.deepEqual(splitPaths(['a\nb']), ['a', 'b']);
+  });
+  it('should split combined', () => {
+    assert.deepEqual(splitPaths(['a\nb;c']), ['a', 'b', 'c']);
+  });
+});
+
+describe('getFiles', () => {
+  const mem = new FsMemory();
+  beforeEach(() => {
+    fsa.register('gf://', mem);
+    mem.files.clear();
+  });
+
+  it('should list files with split paths', async () => {
+    await fsa.write('gf://a/a.txt', Buffer.from('hello world'));
+    await fsa.write('gf://b/b.txt', Buffer.from('hello world'));
+    await fsa.write('gf://c/c.txt', Buffer.from('hello world'));
+
+    const files = await getFiles(['gf://a/;gf://b/\ngf://c/']);
+    assert.deepEqual(files, [['gf://a/a.txt', 'gf://b/b.txt', 'gf://c/c.txt']]);
+  });
+});


### PR DESCRIPTION
#### Motivation

Argo does not easily allow users to add multiple paths to their workflows so users want to 
have a single "path" that is a "\n" or ";" separated
 
#### Modification

Splits all paths on ";" or "\n" 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
