### PR TITLE
fix: uniform checksum s3 metadata key TDE-1181

### DIFF
--- a/src/commands/stac-sync/stac.sync.ts
+++ b/src/commands/stac-sync/stac.sync.ts
@@ -37,7 +37,7 @@ export const commandStacSync = command({
 });
 
 /** Key concatenated to 'x-amz-meta-' */
-export const HashKey = 'linz-hash';
+export const HashKey = 'multihash';
 
 /**
  * Synchronise STAC (JSON) files from a path to another.


### PR DESCRIPTION
#### Motivation

When files are [uploaded to s3 via topo-imagery](https://github.com/linz/topo-imagery/blob/f95d39225e624c8375ad3e9b68d47409f8191a1a/scripts/files/fs_s3.py#L41), their checksum is stored in a s3 metadata key named `-multihash`. In order to keep consistency across our data, we would like to use the same key name everywhere.

#### Modification

Change the S3 metadata key name that store the checksum, when synchronizing the STAC, from `linz-hash` to `multihash`.

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
