### PR TITLE
fix: prevent deadlock when validating bits per sample TDE-1201

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,14 @@ import { run } from 'cmd-ts';
 import { cmd } from './commands/index.js';
 import { logger } from './log.js';
 
-run(cmd, process.argv.slice(2)).catch((err) => {
-  logger.fatal({ err }, 'Command:Failed');
-  logger.flush();
-  // Give the logger some time to flush before exiting
-  setTimeout(() => process.exit(1), 25);
-});
+const startTime = performance.now();
+run(cmd, process.argv.slice(2))
+  .then(() => {
+    logger.debug({ duration: performance.now() - startTime }, 'Command:Done');
+  })
+  .catch((err) => {
+    logger.fatal({ err }, 'Command:Failed');
+    logger.flush();
+    // Give the logger some time to flush before exiting
+    setTimeout(() => process.exit(1), 25);
+  });


### PR DESCRIPTION
#### Motivation

The nodejs event loop is becoming empty due to a deadlock.

The deadlock occurs when the validate8BitTiff attempts to fetch more data from the tiff, the request to fetch the data is added to the TiffQueue, but since `validate8BitTiff` is already inside the `TiffQueue` the fetch can never run which causes the deadlock

#### Modification

Remove the tiff queue from validate8BitTiff as its already inside of the queue.
Add more logs to make it easier to understand if the process exited correctly.

TODO:
Is there a way to detect the deadlock and exit(1)? 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
