### PR TITLE
fix(basemaps): Fix the aerial config path for create pr cli.

### DIFF
--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -109,9 +109,9 @@ export class MakeCogGithub {
       this.createTileSetPullRequest(gh, branch, title, tileSetPath, tileSet);
     } else {
       // Prepare new aerial tileset config
-      const tileSetPath = fsa.joinAll('config', 'tileset', `${filename}.json`);
+      const tileSetPath = fsa.joinAll('config', 'tileset', `aerial.json`);
       const tileSetContent = await gh.getContent(tileSetPath);
-      if (tileSetContent == null) throw new Error(`Unable get the ${filename}.json from config repo.`);
+      if (tileSetContent == null) throw new Error(`Unable get the aerial.json from config repo.`);
       const tileSet = JSON.parse(tileSetContent) as ConfigTileSetRaster;
       const newTileSet = await this.prepareRasterTileSetConfig(layer, tileSet, category);
       // Github create pull request


### PR DESCRIPTION
#### Motivation

The aerial config path is incorrect by using the filename.json, we should hard coded as aerial.json like others topographic.json and elevation.json

#### Modification
Fix the aerial config path to aerial.json

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
