### PR TITLE
fix(basemaps): Keep the existing settings when replacing existing layer.

### DIFF
--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -200,8 +200,9 @@ export class MakeCogGithub {
   ): Promise<ConfigTileSetRaster> {
     // Reprocess existing layer
     for (let i = 0; i < tileSet.layers.length; i++) {
-      if (tileSet.layers[i]?.name === layer.name) {
-        tileSet.layers[i] = layer;
+      const existing = tileSet.layers[i];
+      if (existing?.name === layer.name) {
+        tileSet.layers[i] = { ...existing, ...layer };
         return tileSet;
       }
     }


### PR DESCRIPTION
#### Motivation

When replacing existing layer with the same layer.name, we shouldn't overwrite the whole thing. We need to keep the existing settings like minZoom, maxZoom.

#### Modification

Add existing first and overwrite the duplicated values.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
