### PR TITLE
fix(stac-validate): cache json schema objects to reduce network failures TDE-1212

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+json-schema-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,7 @@ ADD package.json package-lock.json /app/
 RUN npm install --omit=dev
 ADD build/src /app/
 
+# Cache of copy of the STAC JSON schemas by triggering a validation run
+RUN node /app/index.js stac-validate https://nz-imagery.s3-ap-southeast-2.amazonaws.com/new-zealand/new-zealand_2020-2021_10m/rgb/2193/collection.json
+
 ENTRYPOINT ["node", "/app/index.js"]

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -2,6 +2,7 @@ import { fsa } from '@chunkd/fs';
 import Ajv, { DefinedError, SchemaObject, ValidateFunction } from 'ajv';
 import { fastFormats } from 'ajv-formats/dist/formats.js';
 import { boolean, command, flag, number, option, restPositionals, string } from 'cmd-ts';
+import { createHash } from 'crypto';
 import { dirname, join } from 'path';
 import { performance } from 'perf_hooks';
 import * as st from 'stac-ts';
@@ -12,26 +13,25 @@ import { ConcurrentQueue } from '../../utils/concurrent.queue.js';
 import { hashStream } from '../../utils/hash.js';
 import { Sha256Prefix } from '../../utils/hash.js';
 import { config, registerCli, verbose } from '../common.js';
-import { createHash } from 'crypto';
 
 /**
  * Store a local copy of JSON schemas into a cache directory
- * 
+ *
  * This is to prevent overloading the remote hosts as stac validation can trigger lots of schema requests
- * 
+ *
  * @param url JSON schema to load
  * @returns object from the cache if it exists or directly from the uri
  */
-async function readSchema(url:string): Promise<object> {
+async function readSchema(url: string): Promise<object> {
   const cacheId = createHash('sha256').update(url).digest('hex');
   const cachePath = `./json-schema-cache/${cacheId}.json`;
   try {
     return await fsa.readJson<object>(cachePath);
-  } catch(e) {
-    return fsa.readJson<object>(url).then(async obj => {
+  } catch (e) {
+    return fsa.readJson<object>(url).then(async (obj) => {
       await fsa.write(cachePath, JSON.stringify(obj));
-      return obj
-    })
+      return obj;
+    });
   }
 }
 


### PR DESCRIPTION
#### Motivation

_What does this change aim to achieve?_

We are seeing quite a few network related failures when validating JSON schema objects

#### Modification

Cache JSON schema objects locally when the docker container is built

_Why is this change being made? What implications or other considerations are there?_

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
