### PR TITLE
build: only deploy nonprod containers on non release builds

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
         with:
           node-version: 20.x
 
-      # Only build containers on branches otherwise container builds are duplicated deploy-nonprod-containers 
+      # Only build containers on branches otherwise container builds are duplicated deploy-nonprod-containers
       - name: Set up Docker Buildx
         if: ${{ github.ref != 'refs/heads/master' }}
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,10 +7,12 @@ jobs:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
           node-version: 20.x
+
       # Only build containers on branches otherwise container builds are duplicated deploy-nonprod-containers 
       - name: Set up Docker Buildx
         if: ${{ github.ref != 'refs/heads/master' }}
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+
       - name: Build container
         if: ${{ github.ref != 'refs/heads/master' }}
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5
@@ -21,28 +23,37 @@ jobs:
           build-args: |
             GIT_HASH=${{ github.sha }}
             GITHUB_RUN_ID=${{ github.run_id}}
+
   deploy-nonprod-containers:
     runs-on: ubuntu-latest
     concurrency: deploy-dev-${{ github.ref }}
-    # On push to master when it is not a release!
-    if: ${{ github.ref == 'refs/heads/master' && !startsWith(github.event.head_commit.message, 'release:') }}
     needs: ['build']
+
+    # On push to master when it is not a release!
+    if: ${{ github.ref == 'refs/heads/master' && !startsWith(github.event.head_commit.message, 'chore(master): release') }}
+
     permissions:
       id-token: write
       contents: read
       packages: write
+
     env:
       AWS_CI_ROLE: ${{ secrets.AWS_CI_ROLE }}
+
     environment:
       name: nonprod
+
     steps:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
           node-version: 20.x
+
       - name: Download actionlint
         run: docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
+
       - name: Run actionlint to check workflow files
         run: docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -color
+
       - name: Setup GIT version
         id: version
         run: |
@@ -51,11 +62,14 @@ jobs:
           GIT_VERSION_MAJOR_MINOR=$(echo "$GIT_VERSION" | cut -d. -f1,2)
 
           { echo "version=${GIT_VERSION}"; echo "version_major=${GIT_VERSION_MAJOR}"; echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}"; } >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Qemu
         id: qemu
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5
@@ -63,12 +77,14 @@ jobs:
           images: ${{ github.repository }}
           labels: |
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Configure AWS Credentials
         if: ${{env.AWS_CI_ROLE != ''}}
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
@@ -76,10 +92,12 @@ jobs:
           aws-region: ap-southeast-2
           mask-aws-account-id: true
           role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+
       - name: Login to Amazon ECR
         if: ${{env.AWS_CI_ROLE != ''}}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
+
       - name: Setup docker tags
         id: tags
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
@@ -95,6 +113,7 @@ jobs:
               tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
             }
             return tags.join(', ')
+
       - name: Build and push container
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,22 +14,29 @@ jobs:
         with:
           release-type: node
           token: ${{ secrets.GITHUB_TOKEN }}
+
   publish-release:
     needs: release-please
     runs-on: ubuntu-latest
+
     environment:
       name: prod
+
     env:
       AWS_CI_ROLE: ${{ secrets.AWS_CI_ROLE }}
+
     permissions:
       id-token: write
       contents: read
       packages: write
+
     if: ${{ needs.release-please.outputs.release_created }}
+
     steps:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
           node-version: 20.x
+
       - name: Setup GIT version
         id: version
         run: |
@@ -38,11 +45,14 @@ jobs:
           GIT_VERSION_MAJOR_MINOR=$(echo "$GIT_VERSION" | cut -d. -f1,2)
 
           { echo "version=${GIT_VERSION}"; echo "version_major=${GIT_VERSION_MAJOR}"; echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}"; } >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Qemu
         id: qemu
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5
@@ -50,12 +60,14 @@ jobs:
           images: ${{ github.repository }}
           labels: |
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Configure AWS Credentials
         if: ${{ env.AWS_CI_ROLE != '' }}
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
@@ -63,10 +75,12 @@ jobs:
           aws-region: ap-southeast-2
           mask-aws-account-id: true
           role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+
       - name: Login to Amazon ECR
         if: ${{ env.AWS_CI_ROLE != '' }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
+
       - name: Setup docker tags
         id: tags
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
@@ -86,6 +100,7 @@ jobs:
               tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.version.outputs.version }}');
             }
             return tags.join(', ')
+
       - name: Build and push container
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5
         with:


### PR DESCRIPTION
#### Motivation

deploy-nonprod-container job should only run on master merges which are not releases as release-please handles the container builds for everything else

#### Modification

fixes a bad commit message name so it should be ignored.
also re-adds whitespace between steps so its easier to follow

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
