### PR TITLE
build: allow adding label "container" to create containers from pull requests

### DIFF
--- a/.github/workflows/pull-request-container.yml
+++ b/.github/workflows/pull-request-container.yml
@@ -1,0 +1,80 @@
+name: Pull Request Containers
+
+on:
+  pull_request:
+    types:
+      - labeled
+jobs:
+  containers:
+    name: Create containers
+    runs-on: ubuntu-latest
+
+    if: |
+      github.event.label.name == 'container'
+
+    environment:
+      name: nonprod
+
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+
+    steps:
+      - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
+        with:
+          node-version: 20.x
+
+      - name: Setup GIT version
+        id: version
+        run: |
+          GIT_VERSION=$(git describe --tags --always --match 'v*')
+          GIT_VERSION_MAJOR=$(echo "$GIT_VERSION" | cut -d. -f1)
+          GIT_VERSION_MAJOR_MINOR=$(echo "$GIT_VERSION" | cut -d. -f1,2)
+
+          { echo "version=${GIT_VERSION}"; echo "version_major=${GIT_VERSION_MAJOR}"; echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}"; } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Qemu
+        id: qemu
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5
+        with:
+          images: ${{ github.repository }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup docker tags
+        id: tags
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        with:
+          result-encoding: string
+          script: |
+            const tags = [];
+            tags.push('ghcr.io/${{ github.repository }}:pr-${{ github.event.number }}');
+            return tags.join(', ')
+  
+      - name: Build and push container
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5
+        with:
+          context: .
+          tags: ${{ steps.tags.outputs.result }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64,linux/amd64
+          build-args: |
+            GIT_HASH=${{ github.sha }}
+            GIT_VERSION=${{ steps.version.outputs.version }} 
+            GITHUB_RUN_ID=${{ github.run_id}}


### PR DESCRIPTION
#### Motivation

It is useful to be able to test pull requests inside argo using a built container

#### Modification

Users can add "container" label to the pull request to have a pull request for the container to be built

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
