### PR TITLE
fix: include flatten parameter in stac-github-import TDE-1242

### DIFF
--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -129,6 +129,7 @@ export const commandStacGithubImport = command({
       ticket: args.ticket,
       copy_option: args.copyOption,
       region: collection['linz:region'],
+      flatten: 'false',
     };
     const parametersFile = {
       path: `publish-odr-parameters/${collection.id}-${Date.now()}.yaml`,


### PR DESCRIPTION
#### Motivation

Supply the `flatten` parameter to GitHub for the imagery and elevation repos; it is required for the `copy` workflow.

#### Modification

Add a fixed value of `false` for `flatten` to the parameters file added to GitHub.

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
