### PR TITLE
fix: correct GitHub PR title and branch logged

### DIFF
--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -135,7 +135,7 @@ export const commandStacGithubImport = command({
       path: `publish-odr-parameters/${collection.id}-${Date.now()}.yaml`,
       content: JSON.stringify(parametersFileContent, null, 2),
     };
-    logger.info({ commit: `feat: import ${collection.title}`, branch: `feat/bot-${collection.id}` }, 'Git:Commit');
+    logger.info({ commit: `feat: import ${collection.title}`, branch }, 'Git:Commit');
     // create pull request
     await gh.createPullRequest(branch, title, botEmail, [collectionFile, parametersFile], prBody.join('\n'));
   },

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -135,7 +135,7 @@ export const commandStacGithubImport = command({
       path: `publish-odr-parameters/${collection.id}-${Date.now()}.yaml`,
       content: JSON.stringify(parametersFileContent, null, 2),
     };
-    logger.info({ commit: `feat: import ${collection.title}`, branch }, 'Git:Commit');
+    logger.info({ commit: title, branch }, 'Git:Commit');
     // create pull request
     await gh.createPullRequest(branch, title, botEmail, [collectionFile, parametersFile], prBody.join('\n'));
   },


### PR DESCRIPTION
#### Motivation

Capture correct GitHub PR title and branch in the logs.

#### Modification

Use `title` and `branch` consts in the logs.

#### Checklist

Build, formatting and test checks succeed.