### PR TITLE
fix(basemaps): Get the epsg and name correctly for elevation s3 path. BM-1088

### DIFF
--- a/src/commands/basemaps-github/__test__/create-pr.test.ts
+++ b/src/commands/basemaps-github/__test__/create-pr.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { parseTargetUrl, targetInfo } from '../create-pr.js';
+
+describe('parseTargetUrl', () => {
+  it('Should parse the correct target vector Urls', async () => {
+    const target =
+      's3://linz-basemaps/vector/3857/53382-nz-roads-addressing/01HSF04SG9M1P3V667A4NZ1MN8/53382-nz-roads-addressing.tar.co';
+    const { bucket, epsg, name, filename } = parseTargetUrl(target, 1);
+    assert.equal(bucket, 'linz-basemaps');
+    assert.equal(epsg.code, 3857);
+    assert.equal(name, '53382-nz-roads-addressing');
+    assert.equal(filename, '53382-nz-roads-addressing.tar.co');
+  });
+
+  it('Should parse the correct target raster Urls', async () => {
+    const target = 's3://linz-basemaps/3857/canterbury_rural_2014-2015_0-30m_RGBA/01HSF04SG9M1P3V667A4NZ1MN8/';
+    const { bucket, epsg, name, filename } = parseTargetUrl(target, 0);
+    assert.equal(bucket, 'linz-basemaps');
+    assert.equal(epsg.code, 3857);
+    assert.equal(name, 'canterbury_rural_2014-2015_0-30m_RGBA');
+    assert.equal(filename, undefined);
+  });
+
+  it('Should parse the correct target elevation Urls', async () => {
+    const target = 's3://linz-basemaps/elevation/3857/bay-of-plenty_2019-2022_dem_1m/01HSF04SG9M1P3V667A4NZ1MN8/';
+    const { bucket, epsg, name, filename } = parseTargetUrl(target, 1);
+    assert.equal(bucket, 'linz-basemaps');
+    assert.equal(epsg.code, 3857);
+    assert.equal(name, 'bay-of-plenty_2019-2022_dem_1m');
+    assert.equal(filename, undefined);
+  });
+
+  it('Should thrown with incorrect offsets', async () => {
+    const validRaster = 's3://linz-basemaps/3857/bay-of-plenty_2019-2022_dem_1m/01HSF04SG9M1P3V667A4NZ1MN8/';
+    const test1 = (): targetInfo => parseTargetUrl(validRaster, 1);
+    assert.throws(test1, /Invalid target/);
+
+    const validVector =
+      's3://linz-basemaps/vector/3857/53382-nz-roads-addressing/01HSF04SG9M1P3V667A4NZ1MN8/53382-nz-roads-addressing.tar.co';
+    const test2 = (): targetInfo => parseTargetUrl(validVector, 0);
+    assert.throws(test2, /Invalid target/);
+
+    const validElevation =
+      's3://linz-basemaps/elevation/3857/bay-of-plenty_2019-2022_dem_1m/01HSF04SG9M1P3V667A4NZ1MN8/';
+    const test3 = (): targetInfo => parseTargetUrl(validElevation, 0);
+    assert.throws(test3, /Invalid target/);
+  });
+
+  it('Should thrown with incorrect target urls', async () => {
+    const invalidEpsg = 's3://linz-basemaps/999/bay-of-plenty_2019-2022_dem_1m/01HSF04SG9M1P3V667A4NZ1MN8/';
+    const test1 = (): targetInfo => parseTargetUrl(invalidEpsg, 0);
+    assert.throws(test1, /Invalid target/);
+  });
+});

--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -29,14 +29,15 @@ function assertValidBucket(bucket: string, validBuckets: Set<string>): void {
 
 async function parseRasterTargetInfo(
   target: string,
+  elevation: boolean,
   individual: boolean,
 ): Promise<{ name: string; title: string; epsg: EpsgCode; region: string | undefined }> {
   logger.info({ target }, 'CreatePR: Get the layer information from target');
   const url = new URL(target);
   const bucket = url.hostname;
   const splits = url.pathname.split('/');
-  const epsg = Epsg.tryGet(Number(splits[1]));
-  const name = splits[2];
+  const epsg = elevation ? Epsg.tryGet(Number(splits[2])) : Epsg.tryGet(Number(splits[1]));
+  const name = elevation ? splits[3] : splits[2];
 
   assertValidBucket(bucket, validTargetBuckets);
 
@@ -178,7 +179,7 @@ export const basemapsCreatePullRequest = command({
       }
     } else {
       for (const target of targets) {
-        const info = await parseRasterTargetInfo(target, args.individual);
+        const info = await parseRasterTargetInfo(target, category === Category.Elevation, args.individual);
         layer.name = info.name;
         layer.title = info.title;
         layer[info.epsg] = target;


### PR DESCRIPTION
#### Motivation

Elevation s3 path is one more directory and the imagery s3 path. So the validate path need to get the espg and name with the correct index.

elevation: s3://linz-basemaps/elevation/3857/canterbury_2020-2023_dem_1m/01J868QZZ4RJ485PMWP1ECQYD0
imagery: s3://linz-basemaps/2193/gebco_2020_Nztm2000Quad_305-75m/01F1BFJN8R8P7BXN3XTHC5MT5G/

#### Modification

Get the espg and name from correct index for elevations.

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
