### PR TITLE
fix: mapsheet-coverage output filename typo TDE-1164

### DIFF
--- a/src/commands/mapsheet-coverage/__test__/mapsheet.coverage.test.ts
+++ b/src/commands/mapsheet-coverage/__test__/mapsheet.coverage.test.ts
@@ -69,6 +69,7 @@ describe('mapsheet-coverage', () => {
     assert.deepEqual(files, [
       'ms://output/capture-dates.geojson',
       'ms://output/file-list.json',
+      'ms://output/layers-combined.geojson.gz',
       'ms://output/layers-source.geojson.gz',
     ]);
 

--- a/src/commands/mapsheet-coverage/mapsheet.coverage.ts
+++ b/src/commands/mapsheet-coverage/mapsheet.coverage.ts
@@ -27,7 +27,7 @@ const Skip = new Set([
 const ValidCodes = new Set([EpsgCode.Google, EpsgCode.Nztm2000]);
 
 /**
- * Convert a Feature to MultiPolygon, throw if the feature the cannot be easily converted
+ * Convert a Feature to MultiPolygon, throw if the feature cannot be easily converted
  *
  * @throws if the feature is not a Polygon or MultiPolygon
  * @param feature geojson feature to convert
@@ -211,7 +211,7 @@ export const commandMapSheetCoverage = command({
 
     // A single output feature for total capture area
     logger.info('Write:CombinedUnion');
-    const combinedPath = new URL('layers-source.geojson.gz', args.output);
+    const combinedPath = new URL('layers-combined.geojson.gz', args.output);
     await fsa.write(
       urlToString(combinedPath),
       gzipSync(JSON.stringify({ type: 'Feature', geometry: { type: 'MultiPolygon', coordinates: layersCombined } })),


### PR DESCRIPTION
#### Motivation

Fix a small typo that duplicated an output file.

#### Modification

Fixed output file name (and also fixed another, very minor, documentation typo).

#### Checklist

- [x] Tests updated
- [ ] Docs updated N/A not affected
- [x] Issue linked in Title
