### PR TITLE
fix: ensure EAI_AGAIN middleware is added to new file systems TDE-1268

### DIFF
--- a/src/__test__/fs.test.ts
+++ b/src/__test__/fs.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, it } from 'node:test';
+
+import { fsa } from '@chunkd/fs';
+import { FsAwsS3V3 } from '@chunkd/source-aws-v3';
+import { FsMemory } from '@chunkd/source-memory';
+import { FinalizeRequestMiddleware, MetadataBearer } from '@smithy/types';
+import assert from 'assert';
+
+import { setupS3FileSystem } from '../fs.register.js';
+
+export class HttpError extends Error {
+  statusCode: number;
+  constructor(code: number, msg: string) {
+    super(msg);
+    this.statusCode = code;
+  }
+}
+
+describe('Register', () => {
+  const seenBuckets = new Set();
+  const throw403: FinalizeRequestMiddleware<object, MetadataBearer> = (next) => {
+    return async (args) => {
+      const bucket = args.input['Bucket'] as string | undefined;
+      if (bucket == null) return next(args);
+      if (seenBuckets.has(bucket)) throw new HttpError(500, `Bucket: ${bucket} read multiple`);
+      seenBuckets.add(bucket);
+      throw new HttpError(403, 'Something');
+    };
+  };
+
+  beforeEach(async () => {
+    seenBuckets.clear();
+
+    const fsMem = new FsMemory();
+    fsa.register('memory://', fsMem);
+    const config = {
+      prefixes: [
+        { type: 's3', prefix: 's3://linz-topographic/', roleArn: 'a' },
+        { type: 's3', prefix: 's3://linz-topographic-upload/', roleArn: 'a' },
+      ],
+      v: 2,
+    };
+    await fsa.write('memory://config', JSON.stringify(config));
+  });
+
+  it('should add both middleware', async () => {
+    const s3Fs = new FsAwsS3V3();
+    setupS3FileSystem(s3Fs);
+
+    const newFs = new FsAwsS3V3();
+    s3Fs.credentials.onFileSystemCreated({ type: 's3', prefix: 's3://linz-topographic/', roleArn: 'a' }, newFs);
+    assert.equal(
+      newFs.client.middlewareStack.identify().find((f) => f.startsWith('FQDN -')),
+      'FQDN - finalizeRequest',
+    );
+    assert.equal(
+      newFs.client.middlewareStack.identify().find((f) => f.startsWith('EAI_AGAIN -')),
+      'EAI_AGAIN - build',
+    );
+  });
+
+  it('should not duplicate middleware', async () => {
+    const s3Fs = new FsAwsS3V3();
+    setupS3FileSystem(s3Fs);
+    assert.equal(
+      s3Fs.client.middlewareStack.identify().find((f) => f.startsWith('FQDN -')),
+      'FQDN - finalizeRequest',
+    );
+
+    s3Fs.credentials.onFileSystemCreated({ type: 's3', prefix: 's3://linz-topographic/', roleArn: 'a' }, s3Fs);
+    assert.equal(
+      s3Fs.client.middlewareStack.identify().find((f) => f.startsWith('FQDN -')),
+      'FQDN - finalizeRequest',
+    );
+  });
+});


### PR DESCRIPTION
#### Motivation

the middleware to retry EAI_AGAIN errors was not being added to new file systems when they are created, DNS errors on new file systems can still trigger failures.

#### Modification

register EAI_AGAIN middleware onto child file systems 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
