### PR TITLE
fix: ensure file systems with matching roleArns are registered correctly

### DIFF
--- a/src/__test__/fs.test.ts
+++ b/src/__test__/fs.test.ts
@@ -1,11 +1,12 @@
-import { beforeEach, describe, it } from 'node:test';
+import { after, before, beforeEach, describe, it } from 'node:test';
 
-import { fsa } from '@chunkd/fs';
-import { FsAwsS3V3 } from '@chunkd/source-aws-v3';
+import { FileSystemAbstraction, fsa } from '@chunkd/fs';
+import { S3LikeV3 } from '@chunkd/source-aws-v3';
 import { FsMemory } from '@chunkd/source-memory';
+import { FinalizeRequestMiddleware, MetadataBearer } from '@smithy/types';
 import assert from 'assert';
 
-import { setupS3FileSystem } from '../fs.register.js';
+import { registerFileSystem } from '../fs.register.js';
 
 export class HttpError extends Error {
   statusCode: number;
@@ -16,25 +17,48 @@ export class HttpError extends Error {
 }
 
 describe('Register', () => {
+  const seenBuckets = new Set();
+  const throw403: FinalizeRequestMiddleware<object, MetadataBearer> = () => {
+    return async (args: { input: { Bucket?: string } }) => {
+      const bucket = args.input['Bucket'];
+      if (seenBuckets.has(bucket)) throw new HttpError(500, `Bucket: ${bucket} read multiple`);
+      seenBuckets.add(bucket);
+      throw new HttpError(403, 'Something');
+    };
+  };
+
+  // Because these tests modify the singleton "fsa" backup the starting systems then restore them
+  // after all the tests are finished
+  const oldSystems: FileSystemAbstraction['systems'] = [];
+  before(() => oldSystems.push(...fsa.systems));
+  after(() => (fsa.systems = oldSystems));
+
   beforeEach(async () => {
+    fsa.systems.length = 0;
+
+    seenBuckets.clear();
+
     const fsMem = new FsMemory();
+
     fsa.register('memory://', fsMem);
     const config = {
       prefixes: [
-        { type: 's3', prefix: 's3://linz-topographic/', roleArn: 'a' },
-        { type: 's3', prefix: 's3://linz-topographic-upload/', roleArn: 'a' },
+        // `_` is not a valid bucket name
+        { type: 's3', prefix: 's3://_linz-topographic/', roleArn: 'a' },
+        { type: 's3', prefix: 's3://_linz-topographic-upload/', roleArn: 'a' },
       ],
       v: 2,
     };
-    await fsa.write('memory://config', JSON.stringify(config));
+    await fsa.write('memory://config.json', JSON.stringify(config));
   });
 
   it('should add both middleware', async () => {
-    const s3Fs = new FsAwsS3V3();
-    setupS3FileSystem(s3Fs);
+    const s3Fs = registerFileSystem({ config: 'memory://config.json' });
+    await s3Fs.credentials.find('s3://_linz-topographic/foo.json');
 
-    const newFs = new FsAwsS3V3();
-    s3Fs.credentials?.onFileSystemCreated?.({ type: 's3', prefix: 's3://linz-topographic/', roleArn: 'a' }, newFs);
+    const fileSystems = [...s3Fs.credentials.fileSystems.values()];
+    assert.equal(fileSystems.length, 1);
+    const newFs = fileSystems[0]!.s3 as S3LikeV3;
     assert.equal(
       newFs.client.middlewareStack.identify().find((f) => f.startsWith('FQDN -')),
       'FQDN - finalizeRequest',
@@ -46,17 +70,57 @@ describe('Register', () => {
   });
 
   it('should not duplicate middleware', async () => {
-    const s3Fs = new FsAwsS3V3();
-    setupS3FileSystem(s3Fs);
+    const s3Fs = registerFileSystem({ config: 'memory://config.json' });
     assert.equal(
       s3Fs.client.middlewareStack.identify().find((f) => f.startsWith('FQDN -')),
       'FQDN - finalizeRequest',
     );
 
-    s3Fs.credentials?.onFileSystemCreated?.({ type: 's3', prefix: 's3://linz-topographic/', roleArn: 'a' }, s3Fs);
+    await s3Fs.credentials.find('s3://_linz-topographic/foo.json');
+    await s3Fs.credentials.find('s3://_linz-topographic-upload/foo.json');
+
+    const fileSystems = [...s3Fs.credentials.fileSystems.values()];
+    assert.equal(fileSystems.length, 1);
+    const newFs = fileSystems[0]!.s3 as S3LikeV3;
+
     assert.equal(
-      s3Fs.client.middlewareStack.identify().find((f) => f.startsWith('FQDN -')),
+      newFs.client.middlewareStack.identify().find((f) => f.startsWith('FQDN -')),
       'FQDN - finalizeRequest',
     );
+  });
+
+  it('should register all buckets', async (t) => {
+    assert.equal(fsa.systems.length, 1);
+    const s3Fs = registerFileSystem({ config: 'memory://config.json' });
+
+    // All requests to s3 will error with http 403
+    s3Fs.client.middlewareStack.add(throw403, { name: 'throw403', step: 'build' });
+    s3Fs.credentials.registerConfig('memory://config', fsa);
+
+    const fakeTopo = new FsMemory();
+    await fakeTopo.write('s3://_linz-topographic/foo.json', 's3://_linz-topographic/foo.json');
+
+    t.mock.method(s3Fs.credentials, 'createFileSystem', () => fakeTopo);
+
+    assert.equal(
+      fsa.systems.find((f) => f.path === 's3://_linz-topographic/'),
+      undefined,
+    );
+    assert.equal(
+      fsa.systems.find((f) => f.path === 's3://_linz-topographic-upload/'),
+      undefined,
+    );
+
+    const ret = await fsa.read('s3://_linz-topographic/foo.json');
+
+    assert.equal(String(ret), 's3://_linz-topographic/foo.json');
+    assert.ok(fsa.systems.find((f) => f.path === 's3://_linz-topographic/'));
+    assert.equal(
+      fsa.systems.find((f) => f.path === 's3://_linz-topographic-upload/'),
+      undefined,
+    );
+
+    await fsa.exists('s3://_linz-topographic-upload/foo.json');
+    assert.ok(fsa.systems.find((f) => f.path === 's3://_linz-topographic-upload/'));
   });
 });

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -1,10 +1,9 @@
 import { setTimeout } from 'node:timers/promises';
 
 import { S3Client } from '@aws-sdk/client-s3';
-import { FileSystem } from '@chunkd/core';
 import { fsa } from '@chunkd/fs';
-import { AwsCredentialConfig, FsAwsS3 } from '@chunkd/source-aws';
-import { FsAwsS3V3 } from '@chunkd/source-aws-v3';
+import { FsAwsS3 } from '@chunkd/source-aws';
+import { FsAwsS3V3, S3LikeV3 } from '@chunkd/source-aws-v3';
 import { BuildMiddleware, FinalizeRequestMiddleware, MetadataBearer } from '@smithy/types';
 
 import { logger } from './log.js';
@@ -69,25 +68,43 @@ export function eaiAgainBuilder(timeout: (attempt: number) => number): BuildMidd
  * @param fsClient Filesystem to setup
  */
 export function setupS3FileSystem(fsClient: FsAwsS3V3): void {
-  fsClient.credentials.onFileSystemCreated = (acc: AwsCredentialConfig, fs: FileSystem): void => {
-    logger.debug({ prefix: acc.prefix, roleArn: acc.roleArn }, 'FileSystem:Register');
+  addMiddlewareToS3Client(fsClient.client);
 
-    // TODO this cast can be removed once chunkd is upgraded
-    if (fs.protocol === 's3') setupS3FileSystem(fs as FsAwsS3V3);
+  if (fsClient.credentials == null) return;
+  const oldFind = fsClient.credentials.find.bind(fsClient.credentials);
+  // When file systems are looked up ensure they are registered into `fsa`
+  fsClient.credentials.find = async (path: string): Promise<FsAwsS3 | null> => {
+    const accountConfig = await fsClient.credentials.findCredentials(path);
+    if (accountConfig == null) return null;
 
-    fsa.register(acc.prefix, fs);
+    const fileSystem = await oldFind(path);
+    if (fileSystem == null) return null;
+
+    logger.debug({ prefix: path, roleArn: accountConfig.roleArn }, 'FileSystem:Register');
+    fsa.register(accountConfig.prefix, fileSystem);
+    if (fileSystem.s3 && 'client' in fileSystem.s3) {
+      addMiddlewareToS3Client((fileSystem.s3 as S3LikeV3).client);
+    }
+    return fileSystem;
   };
+}
 
+/**
+ * ensure the FQDN and EAI_AGAIN Middleware exist on a s3 client
+ *
+ * @param client
+ */
+export function addMiddlewareToS3Client(client: S3Client): void {
   // There doesnt appear to be a has or find, so the only option is to list all middleware
   // which returns a list in a format: "FQDN - finalizeRequest"
-  const middleware = fsClient.client.middlewareStack.identify();
+  const middleware = client.middlewareStack.identify();
 
   if (middleware.find((f) => f.startsWith('FQDN ')) == null) {
-    fsClient.client.middlewareStack.add(fqdn, { name: 'FQDN', step: 'finalizeRequest' });
+    client.middlewareStack.add(fqdn, { name: 'FQDN', step: 'finalizeRequest' });
   }
 
   if (middleware.find((f) => f.startsWith('EAI_AGAIN ')) == null) {
-    fsClient.client.middlewareStack.add(
+    client.middlewareStack.add(
       eaiAgainBuilder((attempt: number) => 100 + attempt * 1000),
       { name: 'EAI_AGAIN', step: 'build' },
     );
@@ -101,16 +118,18 @@ function splitConfig(x: string): string[] {
   return x.split(',');
 }
 
-export function registerFileSystem(opts: { config?: string }): void {
+export function registerFileSystem(opts: { config?: string }): FsAwsS3V3 {
   const s3Fs = new FsAwsS3V3(new S3Client());
   setupS3FileSystem(s3Fs);
 
   fsa.register('s3://', s3Fs);
 
   const configPath = opts.config ?? process.env['AWS_ROLE_CONFIG_PATH'];
-  if (configPath == null || configPath === '') return;
+  if (configPath == null || configPath === '') return s3Fs;
 
   const paths = splitConfig(configPath);
 
   for (const path of paths) s3Fs.credentials.registerConfig(path, fsa);
+
+  return s3Fs;
 }


### PR DESCRIPTION
#### Motivation

file systems are only created for unique roleArns so FileSystemCreated event is not fired twice if two configuration objects have the same roleArn, 

give a confiugration with two buckets both using `roleA` on a service that has a default role `roleDefault`
```
s3://foo/ - roleA
s3://bar/ - roleA
```

requests to 

```typescript
fs.read("s3://foo"); // tries roleDefault then uses roleA
fs.read("s3://foo"); // uses cached roleA
```

depending on the order of reads the default role may be used far too often

```typescript
fs.read("s3://foo") // tries roleDefault then uses roleA
fs.read("s3://bar") // tries roleDefault then uses roleA
fs.read("s3://bar") // tries roleDefault then uses roleA
```

after this change

```typescript
fs.read("s3://foo") // tries roleDefault then uses roleA
fs.read("s3://bar") // tries roleDefault then uses roleA
fs.read("s3://bar") // uses cached roleA
```


#### Modification

hook the file system finder when it needs to find a new file system use that file system to register onto `fsa` 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
