### PR TITLE
build: add script to generate readme files

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
 
       - name: Generate Readme
         run: |
-          node build/src/readme/readme.generate.js
+          npm run docs
 
       # Validate no READMEs have been updated
       - name: Validate Readme generation

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "docs": "node build/src/readme/readme.generate.js",
     "lint": "npx eslint . --ignore-path .gitignore",
     "test": "node --test build/"
   },


### PR DESCRIPTION
#### Motivation

I want a simplier command to generate the readme files. `npm run docs` after running `npm run build`

#### Modification

- add a `docs` script

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
