### PR TITLE
feat(basemaps): Add nz-elevation bucket as valid source s3 bucket. BM-1088

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -11,7 +11,7 @@ import { registerCli, verbose } from '../common.js';
 import { Category, MakeCogGithub } from './make.cog.github.js';
 
 const validTargetBuckets: Set<string> = new Set(['linz-basemaps', 'linz-basemaps-staging']);
-const validSourceBuckets: Set<string> = new Set(['nz-imagery', 'linz-imagery']);
+const validSourceBuckets: Set<string> = new Set(['nz-imagery', 'linz-imagery', 'nz-elevation']);
 
 export enum ConfigType {
   Raster = 'raster',


### PR DESCRIPTION
#### Motivation

We are now importing elevation data from `nz-elevation` bucket. So, it should be 

#### Modification

Add `nz-elevation` as valid source bucket.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
