### PR TITLE
build: allow pushing pull request builds to aws ecr

### DIFF
--- a/.github/workflows/pull-request-container.yml
+++ b/.github/workflows/pull-request-container.yml
@@ -15,6 +15,9 @@ jobs:
     environment:
       name: nonprod
 
+    env:
+      AWS_CI_ROLE: ${{ secrets.AWS_CI_ROLE }}
+
     permissions:
       id-token: write
       contents: read
@@ -56,6 +59,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure AWS Credentials
+        if: ${{ env.AWS_CI_ROLE != '' }}
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
+        with:
+          aws-region: ap-southeast-2
+          mask-aws-account-id: true
+          role-to-assume: ${{ secrets.AWS_CI_ROLE }}
+
+      - name: Login to Amazon ECR
+        if: ${{ env.AWS_CI_ROLE != '' }}
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
+
       - name: Setup docker tags
         id: tags
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
@@ -64,8 +80,11 @@ jobs:
           script: |
             const tags = [];
             tags.push('ghcr.io/${{ github.repository }}:pr-${{ github.event.number }}');
+            if ("${{ steps.login-ecr.outputs.registry }}") {
+                tags.push('${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:pr-${{ github.event.number }}');
+            }
             return tags.join(', ')
-  
+
       - name: Build and push container
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5
         with:


### PR DESCRIPTION
#### Motivation

Most of our argo templates only allow tags to be changed a lot of them use our ECR based containers, so pull reuqest builds cannot be used inside of argo.

#### Modification

push to AWS ECR if the CI role exists.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
