### PR TITLE
feat: attempt to remove slivers by dropping small polygons TDE-1130

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@linzjs/geojson": "^7.10.0",
         "@octokit/core": "^5.0.0",
         "@octokit/plugin-rest-endpoint-methods": "^10.1.1",
+        "@turf/buffer": "^7.1.0",
         "@wtrpc/core": "^1.0.2",
         "ajv": "^8.17.1",
         "ajv-formats": "^2.1.1",
@@ -2165,6 +2166,112 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@turf/bbox": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.1.0.tgz",
+      "integrity": "sha512-PdWPz9tW86PD78vSZj2fiRaB8JhUHy6piSa/QXb83lucxPK+HTAdzlDQMTKj5okRCU8Ox/25IR2ep9T8NdopRA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.1.0.tgz",
+      "integrity": "sha512-QM3JiCMYA19k5ouO8wJtvICX3Y8XntxVpDfHSKhFFidZcCkMTR2PWWOpwS6EoL3t75rSKw/FOLIPLZGtIu963w==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/center": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "^7.1.0",
+        "@turf/projection": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.1.0.tgz",
+      "integrity": "sha512-p9AvBMwNZmRg65kU27cGKHAUQnEcdz8Y7f/i5DvaMfm4e8zmawr+hzPKXaUpUfiTyLs8Xt2W9vlOmNGyH+6X3w==",
+      "dependencies": {
+        "@turf/bbox": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.1.0.tgz",
+      "integrity": "sha512-5R9qeWvL7FDdBIbEemd0eCzOStr09oburDvJ1hRiPCFX6rPgzcZBQ0gDmZzoF4AFcNLb5IwknbLZjVLaUGWtFA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-+nwOKme/aUprsxnLSfr2LylV6eL6T1Tuln+4Hl92uwZ8FrmjDRCH5Bi1LJNVfWCiYgk8+5K+t2zDphWNTsIFDA==",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.1.0.tgz",
+      "integrity": "sha512-3wHluMoOvXnTe7dfi0kcluTyLNG5MwGsSsK5OA98vkkLH6a1xvItn8e9GcesuT07oB2km/bgefxYEIvjQG5JCA==",
+      "dependencies": {
+        "@turf/clone": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.11",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.11.tgz",
@@ -2883,6 +2990,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "dependencies": {
+        "d3-array": "1"
       }
     },
     "node_modules/data-view-buffer": {
@@ -4711,6 +4831,14 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@linzjs/geojson": "^7.10.0",
     "@octokit/core": "^5.0.0",
     "@octokit/plugin-rest-endpoint-methods": "^10.1.1",
+    "@turf/buffer": "^7.1.0",
     "@wtrpc/core": "^1.0.2",
     "ajv": "^8.17.1",
     "ajv-formats": "^2.1.1",

--- a/src/commands/mapsheet-coverage/__test__/mapsheet.coverage.test.ts
+++ b/src/commands/mapsheet-coverage/__test__/mapsheet.coverage.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { writeFileSync } from 'node:fs';
 import { afterEach, before, describe, it } from 'node:test';
 
 import { Nztm2000QuadTms, Projection } from '@basemaps/geo';
@@ -8,7 +9,7 @@ import { featuresToMultiPolygon } from '@linzjs/geojson';
 import { StacCollection } from 'stac-ts';
 
 import { MapSheet } from '../../../utils/mapsheet.js';
-import { commandMapSheetCoverage } from '../mapsheet.coverage.js';
+import { commandMapSheetCoverage, isLargeRegion } from '../mapsheet.coverage.js';
 
 // convert a collection of map sheets into a multipolygon
 function mapSheetToGeoJson(...sheetCodes: string[]): GeoJSON.Feature {
@@ -198,5 +199,74 @@ describe('mapsheet-coverage', () => {
 
     assert.deepEqual(captureDates.features[0]?.properties?.['source'], 'ms://layers/b/collection.json');
     assert.equal(captureDates.features.length, 1);
+  });
+});
+
+describe('isLargeRegion', () => {
+  const OneMetreInDegrees = 1e-5;
+
+  it('should not remove large polygons', () => {
+    // this polygon is 1 degree x 1 degree at approx 110KM x 110KM
+    assert.equal(
+      isLargeRegion([
+        [
+          [0, 0],
+          [0, -1],
+          [-1, -1],
+          [-1, 0],
+          [0, 0],
+        ],
+      ]),
+      true,
+    );
+  });
+
+  it('should remove polygons with long slivers', () => {
+    // this polygon is 1 degree x 1cm very small slivers
+    // which will be destroyed by the buffering inwards
+    assert.equal(
+      isLargeRegion([
+        [
+          [0, 0],
+          [1, 0],
+          [1, OneMetreInDegrees * 0.01],
+          [0, OneMetreInDegrees * 0.01],
+          [0, 0],
+        ],
+      ]),
+      false,
+    );
+  });
+
+  it('should remove small squares', () => {
+    // this polygon is 1m x 1m, with a area of 1E-10, it should be removed
+    assert.equal(
+      isLargeRegion([
+        [
+          [0, 0],
+          [OneMetreInDegrees, 0],
+          [OneMetreInDegrees, OneMetreInDegrees],
+          [0, OneMetreInDegrees],
+          [0, 0],
+        ],
+      ]),
+      false,
+    );
+  });
+
+  it('should keep medium sized polygons', () => {
+    // this polygon is 100m x 100m
+    assert.equal(
+      isLargeRegion([
+        [
+          [0, 0],
+          [100 * OneMetreInDegrees, 0],
+          [100 * OneMetreInDegrees, 100 * OneMetreInDegrees],
+          [0, 100 * OneMetreInDegrees],
+          [0, 0],
+        ],
+      ]),
+      true,
+    );
   });
 });

--- a/src/commands/mapsheet-coverage/__test__/mapsheet.coverage.test.ts
+++ b/src/commands/mapsheet-coverage/__test__/mapsheet.coverage.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert';
-import { writeFileSync } from 'node:fs';
 import { afterEach, before, describe, it } from 'node:test';
 
 import { Nztm2000QuadTms, Projection } from '@basemaps/geo';

--- a/src/commands/mapsheet-coverage/mapsheet.coverage.ts
+++ b/src/commands/mapsheet-coverage/mapsheet.coverage.ts
@@ -51,12 +51,12 @@ function forceMultiPolygon(f: GeoJSON.Feature): GeoJSON.Feature<GeoJSON.MultiPol
 const DegreesSquareToMetersSquared = 1e-10;
 
 /**
- * Determine if the polygon is a large(ish) region
+ * Determine if the polygon is a large(ish) region,
  *
  * @param poly Polygon in EPSG:4326 (WGS84 lat, lon)
- * @param areaInMeters Polygons that are at least this big are always included without further testing
+ * @param areaInMetersSquared Polygons that are at least this big are always included without further testing
  *
- * @returns if the polygon is considered small
+ * @returns if the polygon is considered large
  */
 export function isLargeRegion(poly: pc.Polygon, areaInMetersSquared: number = 1_000): boolean {
   const polyArea = Area.polygon(poly);

--- a/src/commands/mapsheet-coverage/mapsheet.coverage.ts
+++ b/src/commands/mapsheet-coverage/mapsheet.coverage.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from 'node:fs';
 import { gzipSync } from 'node:zlib';
 
 import { ConfigTileSetRaster } from '@basemaps/config';
@@ -54,14 +53,14 @@ const DegreesSquareToMetersSquared = 1e-10;
 /**
  * Determine if the polygon is a large(ish) region
  *
- * @param poly Polygon in EPSG:4326 (lat, lon)
+ * @param poly Polygon in EPSG:4326 (WGS84 lat, lon)
  * @param areaInMeters Polygons that are at least this big are always included without further testing
  *
  * @returns if the polygon is considered small
  */
-export function isLargeRegion(poly: pc.Polygon, areaInMeters: number = 1_000): boolean {
+export function isLargeRegion(poly: pc.Polygon, areaInMetersSquared: number = 1_000): boolean {
   const polyArea = Area.polygon(poly);
-  const smallArea = areaInMeters * DegreesSquareToMetersSquared;
+  const smallArea = areaInMetersSquared * DegreesSquareToMetersSquared;
 
   // Area is stored as square degrees, 1e-10 is approx 1m^2 (?)
   // TODO: is there a better number than 1e-6, could scale it from the GSD of the dataset
@@ -141,7 +140,7 @@ export const commandMapSheetCoverage = command({
     const captureDates = { type: 'FeatureCollection', features: [] as GeoJSON.Feature[] };
 
     // All the coordinates currently used
-    let layersCombined: pc.MultiPolygon[] = [];
+    let layersCombined: pc.MultiPolygon = [];
 
     // MapSheetName to List of source files required
     const mapSheets = new Map<string, string[]>();

--- a/src/commands/mapsheet-coverage/mapsheet.coverage.ts
+++ b/src/commands/mapsheet-coverage/mapsheet.coverage.ts
@@ -136,8 +136,6 @@ export const commandMapSheetCoverage = command({
 
       const captureArea = forceMultiPolygon(await fsa.readJson<GeoJSON.Feature>(targetCaptureAreaUrl.href));
 
-      // writeFileSync('./' + layer.name + '-capture.area.geojson', JSON.stringify(captureArea));
-
       // As these times are mostly made up, convert them into NZ time to prevent
       // flown years being a year off when the interval is 2023-12-31T12:00:00.000Z (or Jan 1st NZT)
       const flownDates = collection.extent?.temporal?.interval?.[0].map(getPacificAucklandYearMonthDay);
@@ -187,13 +185,15 @@ export const commandMapSheetCoverage = command({
         const polyArea = Area.polygon(poly);
 
         // Area is stored as square degrees, 1e-6 is approx 1m^2 (?)
+        // TODO: is there a better number than 1e-6, could scale it from the GSD of the dataset
         if (polyArea < 1e-6) {
-          // If the buffer in destroys the polygon this polygon likely isnt really useful
+          // If the buffer in destroys the polygon this polygon likely isn't really useful
+          // TODO: 1m works when the dataset is 1m, but not all datasets are 1m resolution
           const bufferedIn = buffer({ type: 'Polygon', coordinates: poly }, -1, { units: 'meters' });
           if (bufferedIn == null) {
             continue;
           }
-          // smallPoly.push(poly);
+          // TODO: should the buffered dataset be used
           diff.push(poly);
         } else {
           diff.push(poly);

--- a/src/commands/mapsheet-coverage/mapsheet.coverage.ts
+++ b/src/commands/mapsheet-coverage/mapsheet.coverage.ts
@@ -1,10 +1,9 @@
-import { writeFileSync } from 'node:fs';
 import { gzipSync } from 'node:zlib';
 
 import { ConfigTileSetRaster } from '@basemaps/config';
-import { EpsgCode, Projection } from '@basemaps/geo';
+import { EpsgCode } from '@basemaps/geo';
 import { fsa } from '@chunkd/fs';
-import { Area, iterate, MultiPolygon, truncate } from '@linzjs/geojson';
+import { Area, truncate } from '@linzjs/geojson';
 import buffer from '@turf/buffer';
 import { command, number, option, optional, string } from 'cmd-ts';
 import pLimit from 'p-limit';


### PR DESCRIPTION
#### Motivation

Quite a few of our datasets are aligned to a EPSG:2193 tile grid, when reprojecting these area polygons to a EPSG:4326, small slithers can appear 

for example in this dataset where one dataset (magenta) has 5 tiles across and one has 4 (blue) only the two corner points are stored

![image (41)](https://github.com/user-attachments/assets/c3302f71-52af-473e-9c77-e08bf481d0ed)

As you zoom in on the corner slithers appear

![image (42)](https://github.com/user-attachments/assets/0202fecd-b564-4056-9421-17e55d9a4e3f)

#### Modification

Find polygons that are very small and drop them.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
