### PR TITLE
feat(basemaps): Update elevation config to insert the source is 2193 layer. BM-1125

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -270,8 +270,9 @@ export const basemapsCreatePullRequest = command({
         layer[info.epsg] = target;
         region = info.region;
       }
+      layer.category = category;
     }
-    layer.category = category;
+
     if (layer.name === '' || layer.title === '') throw new Error('Failed to find the imagery name or title.');
 
     const git = new MakeCogGithub(layer.name, args.repository, args.ticket);


### PR DESCRIPTION
#### Motivation
We got several problems and new features for creating pull request for elevation configs in Basemaps. 
1. 2193 link is missing (this is just the source nz-elevation S3 path)
2. category is included but isn’t included in any of the other configurations
3. minZoom is missing

#### Modification
1. get the source url from collection.json and put in the elevation config as 2193 layer.
2. category was only populate to aerial raster imagery config layers. I have separated all three type of configs and stop populate category for elevation and vector config layers.
3. Add default `minZoom:9` for elevation.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - Tested with Local debug run
- [ ] Docs updated
- [ ] Issue linked in Title
