### PR TITLE
fix(basemaps): Remove the elevation category for elevation layers. BM-1125

### DIFF
--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -309,6 +309,8 @@ export class MakeCogGithub {
     }
 
     this.setDefaultConfig(layer, Category.Elevation);
+    // Remove elevation layer.category if already exists
+    if (layer.category) delete layer.category;
 
     // Prepare elevation tileset config
     for (let i = 0; i < tileSet.layers.length; i++) {


### PR DESCRIPTION
#### Motivation

We don't need `"category": "Elevation",` for elevation combined config. We can delete if exists. The category is only for individual configs and aerial config.

#### Modification

Remove category for combined elevation configs layers

#### Checklist

- [ ] Tests updated - local test
- [ ] Docs updated - no doc
- [x] Issue linked in Title
