### PR TITLE
fix: remove GSD unit from stac setup command inputs TDE-1339 TDE-1211

### DIFF
--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -169,12 +169,12 @@ export const UrlFolder: Type<string, URL> = {
  */
 export const MeterAsString: Type<string, string> = {
   from(str) {
-    const gsd = str.endsWith('m') ? str.slice(0, -1) : str;
+    const meters = str.endsWith('m') ? str.slice(0, -1) : str;
 
-    if (isNaN(Number(gsd))) {
-      throw new Error(`Invalid GSD value: ${gsd}. GSD must be a number.`);
+    if (isNaN(Number(meters))) {
+      throw new Error(`Invalid value: ${meters}. must be a number.`);
     }
 
-    return Promise.resolve(gsd);
+    return Promise.resolve(meters);
   },
 };

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -159,3 +159,22 @@ export const UrlFolder: Type<string, URL> = {
     return url;
   },
 };
+
+/**
+ * Remove a trailing 'm' from a input value and validate the input is a number.
+ *
+ * @param str input value
+ * @returns value without trailing 'm' (if it exists)
+ * @throws if input is not a valid number
+ */
+export const MeterAsString: Type<string, string> = {
+  from(str) {
+    const gsd = str.endsWith('m') ? str.slice(0, -1) : str;
+
+    if (isNaN(Number(gsd))) {
+      throw new Error(`Invalid GSD value: ${gsd}. GSD must be a number.`);
+    }
+
+    return Promise.resolve(gsd);
+  },
+};

--- a/src/commands/stac-setup/README.md
+++ b/src/commands/stac-setup/README.md
@@ -13,7 +13,7 @@ stac-setup <options>
 | --config <str>                 | Location of role configuration file        | optional                         |
 | --start-year <str>             | Start year of survey capture               | optional                         |
 | --end-year <str>               | End year of survey capture                 | optional                         |
-| --gsd <str>                    | GSD of dataset, e.g. 0.3                   |                                  |
+| --gsd <value>                  | GSD of dataset, e.g. 0.3                   |                                  |
 | --region <str>                 | Region of dataset                          |                                  |
 | --geographic-description <str> | Geographic description of dataset          |                                  |
 | --geospatial-category <str>    | Geospatial category of dataset             |                                  |

--- a/src/commands/stac-setup/README.md
+++ b/src/commands/stac-setup/README.md
@@ -13,7 +13,7 @@ stac-setup <options>
 | --config <str>                 | Location of role configuration file        | optional                         |
 | --start-year <str>             | Start year of survey capture               | optional                         |
 | --end-year <str>               | End year of survey capture                 | optional                         |
-| --gsd <str>                    | GSD of dataset                             |                                  |
+| --gsd <str>                    | GSD of dataset, e.g. 0.3                   |                                  |
 | --region <str>                 | Region of dataset                          |                                  |
 | --geographic-description <str> | Geographic description of dataset          |                                  |
 | --geospatial-category <str>    | Geospatial category of dataset             |                                  |

--- a/src/commands/stac-setup/__test__/stac.setup.test.ts
+++ b/src/commands/stac-setup/__test__/stac.setup.test.ts
@@ -207,13 +207,10 @@ describe('checkGsd', () => {
   });
 
   it('Should throw error if GSD is not a number', async () => {
-    await assert.rejects(
-      async () => await MeterAsString.from('foo'),
-      Error('Invalid GSD value: foo. GSD must be a number.'),
-    );
+    await assert.rejects(async () => await MeterAsString.from('foo'), Error('Invalid value: foo. must be a number.'));
     await assert.rejects(
       async () => await MeterAsString.from('1.4deg'),
-      Error('Invalid GSD value: 1.4deg. GSD must be a number.'),
+      Error('Invalid value: 1.4deg. must be a number.'),
     );
   });
 });

--- a/src/commands/stac-setup/__test__/stac.setup.test.ts
+++ b/src/commands/stac-setup/__test__/stac.setup.test.ts
@@ -205,7 +205,6 @@ describe('formatGsd', () => {
   });
 
   it('Should return GSD with trailing m removed', async () => {
-    const gsd = '0.3m';
-    assert.equal(formatGsd(gsd), '0.3');
+    assert.equal(formatGsd('0.3m'), '0.3');
   });
 });

--- a/src/commands/stac-setup/__test__/stac.setup.test.ts
+++ b/src/commands/stac-setup/__test__/stac.setup.test.ts
@@ -4,8 +4,8 @@ import { afterEach, before, describe, it } from 'node:test';
 import { fsa } from '@chunkd/fs';
 import { FsMemory } from '@chunkd/source-memory';
 
-import { commandStacSetup } from '../stac.setup.js';
-import { checkGsd, formatDate, slugFromMetadata, SlugMetadata } from '../stac.setup.js';
+import { MeterAsString } from '../../common.js';
+import { commandStacSetup, formatDate, slugFromMetadata, SlugMetadata } from '../stac.setup.js';
 import { SampleCollection } from './sample.js';
 
 describe('stac-setup', () => {
@@ -199,14 +199,21 @@ describe('formatDate', () => {
 
 describe('checkGsd', () => {
   it('Should return GSD unaltered', async () => {
-    assert.equal(checkGsd('0.3'), '0.3');
+    assert.equal(await MeterAsString.from('0.3'), '0.3');
   });
+
   it('Should return GSD with trailing m removed', async () => {
-    assert.equal(checkGsd('0.3m'), '0.3');
+    assert.equal(await MeterAsString.from('0.3m'), '0.3');
   });
+
   it('Should throw error if GSD is not a number', async () => {
-    assert.throws(() => {
-      checkGsd('foo');
-    }, Error('Invalid GSD value: foo. GSD must be a number.'));
+    await assert.rejects(
+      async () => await MeterAsString.from('foo'),
+      Error('Invalid GSD value: foo. GSD must be a number.'),
+    );
+    await assert.rejects(
+      async () => await MeterAsString.from('1.4deg'),
+      Error('Invalid GSD value: 1.4deg. GSD must be a number.'),
+    );
   });
 });

--- a/src/commands/stac-setup/__test__/stac.setup.test.ts
+++ b/src/commands/stac-setup/__test__/stac.setup.test.ts
@@ -5,7 +5,7 @@ import { fsa } from '@chunkd/fs';
 import { FsMemory } from '@chunkd/source-memory';
 
 import { commandStacSetup } from '../stac.setup.js';
-import { formatDate, slugFromMetadata, SlugMetadata } from '../stac.setup.js';
+import { formatDate, formatGsd, slugFromMetadata, SlugMetadata } from '../stac.setup.js';
 import { SampleCollection } from './sample.js';
 
 describe('stac-setup', () => {
@@ -195,5 +195,17 @@ describe('formatDate', () => {
     const startYear = '2023';
     const endYear = '2024';
     assert.equal(formatDate(startYear, endYear), '2023-2024');
+  });
+});
+
+describe('formatGsd', () => {
+  it('Should return GSD unaltered', async () => {
+    const gsd = '0.3';
+    assert.equal(formatGsd(gsd), '0.3');
+  });
+
+  it('Should return GSD with trailing m removed', async () => {
+    const gsd = '0.3m';
+    assert.equal(formatGsd(gsd), '0.3');
   });
 });

--- a/src/commands/stac-setup/__test__/stac.setup.test.ts
+++ b/src/commands/stac-setup/__test__/stac.setup.test.ts
@@ -5,7 +5,7 @@ import { fsa } from '@chunkd/fs';
 import { FsMemory } from '@chunkd/source-memory';
 
 import { commandStacSetup } from '../stac.setup.js';
-import { formatDate, formatGsd, slugFromMetadata, SlugMetadata } from '../stac.setup.js';
+import { checkGsd, formatDate, slugFromMetadata, SlugMetadata } from '../stac.setup.js';
 import { SampleCollection } from './sample.js';
 
 describe('stac-setup', () => {
@@ -190,7 +190,6 @@ describe('formatDate', () => {
     const endYear = '2023';
     assert.equal(formatDate(startYear, endYear), '2023');
   });
-
   it('Should return date as two years', async () => {
     const startYear = '2023';
     const endYear = '2024';
@@ -198,12 +197,16 @@ describe('formatDate', () => {
   });
 });
 
-describe('formatGsd', () => {
+describe('checkGsd', () => {
   it('Should return GSD unaltered', async () => {
-    assert.equal(formatGsd('0.3'), '0.3');
+    assert.equal(checkGsd('0.3'), '0.3');
   });
-
   it('Should return GSD with trailing m removed', async () => {
-    assert.equal(formatGsd('0.3m'), '0.3');
+    assert.equal(checkGsd('0.3m'), '0.3');
+  });
+  it('Should throw error if GSD is not a number', async () => {
+    assert.throws(() => {
+      checkGsd('foo');
+    }, Error('Invalid GSD value: foo. GSD must be a number.'));
   });
 });

--- a/src/commands/stac-setup/__test__/stac.setup.test.ts
+++ b/src/commands/stac-setup/__test__/stac.setup.test.ts
@@ -200,8 +200,7 @@ describe('formatDate', () => {
 
 describe('formatGsd', () => {
   it('Should return GSD unaltered', async () => {
-    const gsd = '0.3';
-    assert.equal(formatGsd(gsd), '0.3');
+    assert.equal(formatGsd('0.3'), '0.3');
   });
 
   it('Should return GSD with trailing m removed', async () => {

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -102,7 +102,7 @@ export const commandStacSetup = command({
         region: args.region,
         geographicDescription: args.geographicDescription,
         date: date,
-        gsd: args.gsd,
+        gsd: formatGsd(args.gsd),
       };
       const slug = slugFromMetadata(metadata);
       const collectionId = ulid.ulid();
@@ -141,6 +141,20 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
   }
 
   throw new Error(`Slug can't be generated from collection as no matching category: ${metadata.geospatialCategory}.`);
+}
+
+/**
+ * Remove a trailing 'm' from a GSD value and log warning if it is present
+ *
+ * @param gsd GSD value from command line input
+ * @returns GSD without trailing 'm'
+ */
+export function formatGsd(gsd: string): string {
+  if (gsd.endsWith('m')) {
+    logger.warn(`${gsd} supplied as GSD; future supported format will require numerical value only.`);
+    return gsd.slice(0, -1);
+  }
+  return gsd;
 }
 
 /**

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -123,19 +123,16 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
   const slug = slugify(metadata.date ? `${geographicDescription}_${metadata.date}` : geographicDescription);
 
   if (
-    (
-      [
-        GeospatialDataCategories.AerialPhotos,
-        GeospatialDataCategories.RuralAerialPhotos,
-        GeospatialDataCategories.SatelliteImagery,
-        GeospatialDataCategories.UrbanAerialPhotos,
-      ] as string[]
-    ).includes(metadata.geospatialCategory)
+    metadata.geospatialCategory === GeospatialDataCategories.AerialPhotos ||
+    metadata.geospatialCategory === GeospatialDataCategories.RuralAerialPhotos ||
+    metadata.geospatialCategory === GeospatialDataCategories.SatelliteImagery ||
+    metadata.geospatialCategory === GeospatialDataCategories.UrbanAerialPhotos
   ) {
     return `${slug}_${metadata.gsd}m`;
   }
   if (
-    ([GeospatialDataCategories.Dem, GeospatialDataCategories.Dsm] as string[]).includes(metadata.geospatialCategory)
+    metadata.geospatialCategory === GeospatialDataCategories.Dem ||
+    metadata.geospatialCategory === GeospatialDataCategories.Dsm
   ) {
     return slug;
   }

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -41,7 +41,7 @@ export const commandStacSetup = command({
     gsd: option({
       type: string,
       long: 'gsd',
-      description: 'GSD of dataset',
+      description: 'GSD of dataset, e.g. 0.3',
     }),
 
     region: option({
@@ -102,7 +102,7 @@ export const commandStacSetup = command({
         region: args.region,
         geographicDescription: args.geographicDescription,
         date: date,
-        gsd: formatGsd(args.gsd),
+        gsd: checkGsd(args.gsd),
       };
       const slug = slugFromMetadata(metadata);
       const collectionId = ulid.ulid();
@@ -144,15 +144,19 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
 }
 
 /**
- * Remove a trailing 'm' from a GSD value and log warning if it is present
+ * Remove a trailing 'm' from a GSD value, logging warning if it is present. Check if GSD is a number.
  *
  * @param gsd GSD value from command line input
  * @returns GSD without trailing 'm'
  */
-export function formatGsd(gsd: string): string {
-  if (gsd.endsWith('m')) {
-    logger.warn(`${gsd} supplied as GSD; future supported format will require numerical value only.`);
-    return gsd.slice(0, -1);
+export function checkGsd(suppliedGsd: string): string {
+  let gsd = suppliedGsd;
+  if (suppliedGsd.endsWith('m')) {
+    logger.warn(`${suppliedGsd} supplied as GSD; future supported format will require numerical value only.`);
+    gsd = suppliedGsd.slice(0, -1);
+  }
+  if (isNaN(Number(gsd))) {
+    throw new Error(`Invalid GSD value: ${gsd}. GSD must be a number.`);
   }
   return gsd;
 }

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -7,7 +7,7 @@ import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
 import { GeospatialDataCategories, StacCollectionLinz } from '../../utils/metadata.js';
 import { slugify } from '../../utils/slugify.js';
-import { config, registerCli, tryParseUrl, UrlFolder, urlToString, verbose } from '../common.js';
+import { config, MeterAsString, registerCli, tryParseUrl, UrlFolder, urlToString, verbose } from '../common.js';
 
 export interface SlugMetadata {
   geospatialCategory: string;
@@ -39,7 +39,7 @@ export const commandStacSetup = command({
     }),
 
     gsd: option({
-      type: string,
+      type: MeterAsString,
       long: 'gsd',
       description: 'GSD of dataset, e.g. 0.3',
     }),
@@ -102,7 +102,7 @@ export const commandStacSetup = command({
         region: args.region,
         geographicDescription: args.geographicDescription,
         date: date,
-        gsd: checkGsd(args.gsd),
+        gsd: args.gsd,
       };
       const slug = slugFromMetadata(metadata);
       const collectionId = ulid.ulid();
@@ -141,23 +141,6 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
   }
 
   throw new Error(`Slug can't be generated from collection as no matching category: ${metadata.geospatialCategory}.`);
-}
-
-/**
- * Remove a trailing 'm' from a GSD value, logging warning if it is present. Check if GSD is a number.
- *
- * @param gsd GSD value from command line input
- * @returns GSD without trailing 'm'
- */
-export function checkGsd(suppliedGsd: string): string {
-  let gsd = suppliedGsd;
-  if (suppliedGsd.endsWith('m')) {
-    gsd = suppliedGsd.slice(0, -1);
-  }
-  if (isNaN(Number(gsd))) {
-    throw new Error(`Invalid GSD value: ${gsd}. GSD must be a number.`);
-  }
-  return gsd;
 }
 
 /**

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -152,7 +152,6 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
 export function checkGsd(suppliedGsd: string): string {
   let gsd = suppliedGsd;
   if (suppliedGsd.endsWith('m')) {
-    logger.warn(`${suppliedGsd} supplied as GSD; future supported format will require numerical value only.`);
     gsd = suppliedGsd.slice(0, -1);
   }
   if (isNaN(Number(gsd))) {


### PR DESCRIPTION
#### Motivation

A change was made recently to accept the GSD in the format without a trailing `m` e.g. `0.3` rather than `0.3m`. However, the old format should still be accepted as this may accidentally be entered as a workflow parameter.

#### Modification

Small refactor to match refactor made to `generate-path` command when handling `GeospatialDataCategories`.
Add a function `formatGsd` to check the format of the GSD, remove a trailing `m` and log a warning.

#### Checklist

- [x] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
