### PR TITLE
feat: improve stac-validate logs TDE-1385

### DIFF
--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -308,24 +308,27 @@ export async function validateStacChecksum(
 
   if (checksum == null) {
     if (allowMissing) return true;
-    logger.error({ source, checksum }, 'Validate:Checksum:Missing');
+    logger.error({ source, checksum, type: stacObject.rel, parent: path }, 'Validate:Checksum:Missing');
     return false;
   }
 
   if (!checksum.startsWith(Sha256Prefix)) {
-    logger.error({ source, checksum }, 'Validate:Checksum:Unknown');
+    logger.error({ source, checksum, type: stacObject.rel, parent: path }, 'Validate:Checksum:Unknown');
     return false;
   }
   logger.debug({ source, checksum }, 'Validate:Checksum');
   const startTime = performance.now();
   const hash = await hashStream(fsa.stream(source));
   const duration = performance.now() - startTime;
-
+  stacObject.rel;
   if (hash !== checksum) {
-    logger.error({ source, checksum, found: hash, duration }, 'Checksum:Validation:Failed');
+    logger.error(
+      { source, checksum, found: hash, type: stacObject.rel, parent: path, duration },
+      'Checksum:Validation:Failed',
+    );
     return false;
   }
-  logger.debug({ source, checksum, duration }, 'Checksum:Validation:Ok');
+  logger.debug({ source, checksum, type: stacObject.rel, parent: path, duration }, 'Checksum:Validation:Ok');
   return true;
 }
 

--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -320,7 +320,7 @@ export async function validateStacChecksum(
   const startTime = performance.now();
   const hash = await hashStream(fsa.stream(source));
   const duration = performance.now() - startTime;
-  stacObject.rel;
+
   if (hash !== checksum) {
     logger.error(
       { source, checksum, found: hash, type: stacObject.rel, parent: path, duration },


### PR DESCRIPTION
#### Motivation

When a STAC validation fails on a link checksum, it requires some manual research to find which is the parent document that contains this failing link.

#### Modification

Add the following information in the checksum validation logs:

- Add the STAC document path of the parent that contains the link being checked
- Add the link rel or "type"

``` json
{"level":20,"time":1738618069598,"pid":129823,"hostname":"linz","id":"01JK6VCRF3BXTHK5HT9YZ11MZV","source":"memory://stac/item.json","checksum":"12206fd977db9b2afe87a9ceee48432881299a6aaf83d935fbbe83007660287f9c2e","type":"item","parent":"memory://stac/collection.json","duration":0.16163199999999733,"msg":"Checksum:Validation:Ok"}
```
#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [X] Issue linked in Title
