### PR TITLE
feat: generate paths for new national hillshade products TDE-1378

### DIFF
--- a/src/commands/generate-path/__test__/generate.path.test.ts
+++ b/src/commands/generate-path/__test__/generate.path.test.ts
@@ -19,6 +19,57 @@ describe('GeneratePathImagery', () => {
   });
 });
 
+describe('GeneratePathHillshade', () => {
+  it('Should match - hillshade 8m igor', () => {
+    const metadata: PathMetadata = {
+      targetBucketName: 'nz-elevation',
+      geospatialCategory: 'dem-hillshade-igor',
+      region: 'new-zealand',
+      slug: 'new-zealand-contour',
+      gsd: 8,
+      epsg: 2193,
+    };
+    assert.equal(
+      generatePath(metadata),
+      's3://nz-elevation/new-zealand/new-zealand-contour/dem-hillshade-igor_8m/2193/',
+    );
+  });
+
+  it('Should match - hillshade 8m default', () => {
+    const metadata: PathMetadata = {
+      targetBucketName: 'nz-elevation',
+      geospatialCategory: 'dem-hillshade',
+      region: 'new-zealand',
+      slug: 'new-zealand-contour',
+      gsd: 8,
+      epsg: 2193,
+    };
+    assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand-contour/dem-hillshade_8m/2193/');
+  });
+  it('Should match - hillshade combined igor', () => {
+    const metadata: PathMetadata = {
+      targetBucketName: 'nz-elevation',
+      geospatialCategory: 'dem-hillshade-igor',
+      region: 'new-zealand',
+      slug: 'new-zealand',
+      gsd: 1,
+      epsg: 2193,
+    };
+    assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dem-hillshade-igor/2193/');
+  });
+  it('Should match - hillshade combined default', () => {
+    const metadata: PathMetadata = {
+      targetBucketName: 'nz-elevation',
+      geospatialCategory: 'dem-hillshade',
+      region: 'new-zealand',
+      slug: 'new-zealand',
+      gsd: 1,
+      epsg: 2193,
+    };
+    assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dem-hillshade/2193/');
+  });
+});
+
 describe('GeneratePathGeospatialDataCategories', () => {
   it('Should match - dem from slug', () => {
     const metadata: PathMetadata = {

--- a/src/commands/generate-path/path.generate.ts
+++ b/src/commands/generate-path/path.generate.ts
@@ -92,9 +92,19 @@ export function generatePath(metadata: PathMetadata): string {
 
   if (
     metadata.geospatialCategory === GeospatialDataCategories.Dem ||
-    metadata.geospatialCategory === GeospatialDataCategories.Dsm
+    metadata.geospatialCategory === GeospatialDataCategories.Dsm ||
+    (metadata.gsd === 8 &&
+      (metadata.geospatialCategory === GeospatialDataCategories.DemHillshade ||
+        metadata.geospatialCategory === GeospatialDataCategories.DemHillshadeIgor))
   ) {
     return `s3://${metadata.targetBucketName}/${metadata.region}/${metadata.slug}/${metadata.geospatialCategory}_${metadata.gsd}m/${metadata.epsg}/`;
+  }
+
+  if (
+    metadata.geospatialCategory === GeospatialDataCategories.DemHillshade ||
+    metadata.geospatialCategory === GeospatialDataCategories.DemHillshadeIgor
+  ) {
+    return `s3://${metadata.targetBucketName}/${metadata.region}/${metadata.slug}/${metadata.geospatialCategory}/${metadata.epsg}/`;
   }
 
   throw new Error(

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -132,7 +132,9 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
   }
   if (
     metadata.geospatialCategory === GeospatialDataCategories.Dem ||
-    metadata.geospatialCategory === GeospatialDataCategories.Dsm
+    metadata.geospatialCategory === GeospatialDataCategories.Dsm ||
+    metadata.geospatialCategory === GeospatialDataCategories.DemHillshade ||
+    metadata.geospatialCategory === GeospatialDataCategories.DemHillshadeIgor
   ) {
     return slug;
   }

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -16,6 +16,8 @@ export const GeospatialDataCategories = {
   UrbanAerialPhotos: 'urban-aerial-photos',
   Dem: 'dem',
   Dsm: 'dsm',
+  DemHillshade: 'dem-hillshade',
+  DemHillshadeIgor: 'dem-hillshade-igor',
 } as const;
 
 export type GeospatialDataCategory = (typeof GeospatialDataCategories)[keyof typeof GeospatialDataCategories];


### PR DESCRIPTION
#### Motivation

To generate a national combined hillshade product, we need to be able generate correct output paths when processing the datasets.

#### Modification

- Added tests
- Added GeospatialDataCategories
- Added path template for newly created categories 
- Updated `slugFromMetadata` for basic support of hillshade datasets


#### Checklist

- [x] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
Docs: no changes to usage of `generate-path` that require an update to the readme files.