### PR TITLE
feat(stac-setup): support historical survey names LI-3977

### DIFF
--- a/src/commands/stac-setup/README.md
+++ b/src/commands/stac-setup/README.md
@@ -8,17 +8,18 @@ stac-setup <options>
 
 ### Options
 
-| Usage                          | Description                                | Options                          |
-| ------------------------------ | ------------------------------------------ | -------------------------------- |
-| --config <str>                 | Location of role configuration file        | optional                         |
-| --start-year <str>             | Start year of survey capture               | optional                         |
-| --end-year <str>               | End year of survey capture                 | optional                         |
-| --gsd <value>                  | GSD of dataset, e.g. 0.3                   |                                  |
-| --region <str>                 | Region of dataset                          |                                  |
-| --geographic-description <str> | Geographic description of dataset          |                                  |
-| --geospatial-category <str>    | Geospatial category of dataset             |                                  |
-| --odr-url <str>                | Open Data Registry URL of existing dataset | optional                         |
-| --output <value>               | Where to store output files                | default: file:///tmp/stac-setup/ |
+| Usage                          | Description                                 | Options                          |
+| ------------------------------ | ------------------------------------------- | -------------------------------- |
+| --config <str>                 | Location of role configuration file         | optional                         |
+| --start-year <str>             | Start year of survey capture                | optional                         |
+| --end-year <str>               | End year of survey capture                  | optional                         |
+| --gsd <value>                  | GSD of dataset, e.g. 0.3                    |                                  |
+| --region <str>                 | Region of dataset                           |                                  |
+| --geographic-description <str> | Geographic description of dataset           |                                  |
+| --survey-id <str>              | Associated survey id, eg SN8066 or SNC20505 | optional                         |
+| --geospatial-category <str>    | Geospatial category of dataset              |                                  |
+| --odr-url <str>                | Open Data Registry URL of existing dataset  | optional                         |
+| --output <value>               | Where to store output files                 | default: file:///tmp/stac-setup/ |
 
 ### Flags
 

--- a/src/commands/stac-setup/__test__/stac.setup.test.ts
+++ b/src/commands/stac-setup/__test__/stac.setup.test.ts
@@ -20,18 +20,23 @@ describe('stac-setup', () => {
     mem.files.clear();
   });
 
+  const BaseArgs = {
+    verbose: false,
+    config: undefined,
+    surveyId: undefined,
+  };
+
   it('should retrieve setup from collection', async () => {
     const baseArgs = {
+      ...BaseArgs,
       odrUrl: 'memory://collection.json',
       output: new URL('memory://tmp/stac-setup/'),
-      verbose: false,
       startYear: '2013',
       endYear: '2014',
       gsd: '1',
       region: 'gisborne',
       geographicDescription: 'Wairoa',
       geospatialCategory: 'dem',
-      config: undefined,
     } as const;
     await fsa.write('memory://collection.json', JSON.stringify(structuredClone(SampleCollection)));
     await commandStacSetup.handler(baseArgs);
@@ -47,16 +52,15 @@ describe('stac-setup', () => {
 
   it('should retrieve setup from args', async () => {
     const baseArgs = {
+      ...BaseArgs,
       odrUrl: '',
       output: new URL('memory://tmp/stac-setup/'),
-      verbose: false,
       startYear: '2013',
       endYear: '2014',
       gsd: '1',
       region: 'gisborne',
       geographicDescription: 'Wairoa',
       geospatialCategory: 'dem',
-      config: undefined,
     } as const;
     await commandStacSetup.handler(baseArgs);
 
@@ -71,16 +75,15 @@ describe('stac-setup', () => {
 
   it('should not include the date in the slug', async () => {
     const baseArgs = {
+      ...BaseArgs,
       odrUrl: '',
       output: new URL('memory://tmp/stac-setup/'),
-      verbose: false,
       startYear: '',
       endYear: '',
       gsd: '10',
       region: 'new-zealand',
       geographicDescription: '',
       geospatialCategory: 'dem',
-      config: undefined,
     } as const;
     await commandStacSetup.handler(baseArgs);
 
@@ -93,9 +96,9 @@ describe('stac-setup', () => {
 
   it('should generate a slug with a survey id', async () => {
     const baseArgs = {
+      ...BaseArgs,
       odrUrl: '',
       output: new URL('memory://tmp/stac-setup/'),
-      verbose: false,
       startYear: '1982',
       endYear: '1983',
       gsd: '0.375',
@@ -103,7 +106,6 @@ describe('stac-setup', () => {
       surveyId: 'SN8066',
       geographicDescription: 'Chatham Islands',
       geospatialCategory: 'scanned-aerial-photos',
-      config: undefined,
     } as const;
     await commandStacSetup.handler(baseArgs);
 
@@ -112,7 +114,7 @@ describe('stac-setup', () => {
   });
 });
 
-describe('GenerateSlugImagery', () => {
+describe('slugFromMetadata', () => {
   it('Should match - urban with geographic description', () => {
     const metadata: SlugMetadata = {
       geospatialCategory: 'urban-aerial-photos',
@@ -143,9 +145,7 @@ describe('GenerateSlugImagery', () => {
     };
     assert.equal(slugFromMetadata(metadata), 'auckland_2023_0.3m');
   });
-});
 
-describe('GenerateSlugGeospatialDataCategories', () => {
   it('Should match - dem (no optional metadata)', () => {
     const metadata: SlugMetadata = {
       geospatialCategory: 'dem',
@@ -191,9 +191,7 @@ describe('GenerateSlugGeospatialDataCategories', () => {
       slugFromMetadata(metadata);
     }, Error("Slug can't be generated from collection as no matching category: not-a-valid-category."));
   });
-});
 
-describe('GenerateSlugDemIgnoringDate', () => {
   it('Should not include the date in the slug', () => {
     const metadata: SlugMetadata = {
       geospatialCategory: 'dem',
@@ -204,18 +202,35 @@ describe('GenerateSlugDemIgnoringDate', () => {
     };
     assert.equal(slugFromMetadata(metadata), 'new-zealand');
   });
+
+  it('should support geographicDescription with historical imagery', () => {
+    assert.equal(
+      slugFromMetadata({
+        geospatialCategory: 'scanned-aerial-photos',
+        surveyId: 'SN8066',
+        region: 'auckland',
+        geographicDescription: 'West-Coast',
+        gsd: '0.35',
+        date: '1982',
+      }),
+      'west-coast_sn8066_1982_0.35m',
+    );
+  });
 });
 
 describe('formatDate', () => {
   it('Should return date as single year', async () => {
-    const startYear = '2023';
-    const endYear = '2023';
-    assert.equal(formatDate(startYear, endYear), '2023');
+    assert.equal(formatDate('2023', '2023'), '2023');
   });
   it('Should return date as two years', async () => {
-    const startYear = '2023';
-    const endYear = '2024';
-    assert.equal(formatDate(startYear, endYear), '2023-2024');
+    assert.equal(formatDate('2023', '2024'), '2023-2024');
+  });
+  it('Should only return a data if both are set', () => {
+    assert.equal(formatDate(undefined, '2023'), '');
+    assert.equal(formatDate('', '2023'), '');
+
+    assert.equal(formatDate('2023', undefined), '');
+    assert.equal(formatDate('2023', ''), '');
   });
 });
 

--- a/src/commands/stac-setup/__test__/stac.setup.test.ts
+++ b/src/commands/stac-setup/__test__/stac.setup.test.ts
@@ -225,7 +225,7 @@ describe('formatDate', () => {
   it('Should return date as two years', async () => {
     assert.equal(formatDate('2023', '2024'), '2023-2024');
   });
-  it('Should only return a data if both are set', () => {
+  it('Should only return a date if both are set', () => {
     assert.equal(formatDate(undefined, '2023'), '');
     assert.equal(formatDate('', '2023'), '');
 

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -5,14 +5,16 @@ import ulid from 'ulid';
 
 import { CliInfo } from '../../cli.info.js';
 import { logger } from '../../log.js';
-import { GeospatialDataCategories, StacCollectionLinz } from '../../utils/metadata.js';
+import { GeospatialDataCategory, StacCollectionLinz } from '../../utils/metadata.js';
 import { slugify } from '../../utils/slugify.js';
 import { config, MeterAsString, registerCli, tryParseUrl, UrlFolder, urlToString, verbose } from '../common.js';
 
 export interface SlugMetadata {
-  geospatialCategory: string;
+  geospatialCategory: GeospatialDataCategory;
   geographicDescription?: string;
   region: string;
+  /** Optional survey ID if it exists, eg SN8066, commonly used with scanned historical imagery */
+  surveyId?: string;
   date: string;
   gsd: string;
 }
@@ -56,6 +58,12 @@ export const commandStacSetup = command({
       description: 'Geographic description of dataset',
     }),
 
+    surveyId: option({
+      type: string,
+      long: 'survey-id',
+      description: 'Associated survey id, eg SN8066 or SNC20505',
+    }),
+
     geospatialCategory: option({
       type: string,
       long: 'geospatial-category',
@@ -80,7 +88,6 @@ export const commandStacSetup = command({
   async handler(args) {
     registerCli(this, args);
     const startTime = performance.now();
-    const date = args.startYear && args.endYear ? formatDate(args.startYear, args.endYear) : '';
 
     logger.info('StacSetup:Start');
     if (args.odrUrl) {
@@ -90,9 +97,8 @@ export const commandStacSetup = command({
       const collection = await fsa.readJson<StacCollection & StacCollectionLinz>(collectionPath);
       if (collection == null) throw new Error(`Failed to get collection.json from ${args.odrUrl}.`);
       const slug = collection['linz:slug'];
-      if (slug !== slugify(slug)) {
-        throw new Error(`Invalid slug: ${slug}.`);
-      }
+      if (slug !== slugify(slug)) throw new Error(`Invalid slug: ${slug}.`);
+
       const collectionId = collection['id'];
       await writeSetupFiles(slug, collectionId, args.output);
       logger.info({ duration: performance.now() - startTime, slug, collectionId }, 'StacSetup:Done');
@@ -100,8 +106,9 @@ export const commandStacSetup = command({
       const metadata: SlugMetadata = {
         geospatialCategory: args.geospatialCategory,
         region: args.region,
+        surveyId: args.surveyId,
         geographicDescription: args.geographicDescription,
-        date: date,
+        date: formatDate(args.startYear, args.endYear),
         gsd: args.gsd,
       };
       const slug = slugFromMetadata(metadata);
@@ -112,6 +119,10 @@ export const commandStacSetup = command({
   },
 });
 
+function formatParts(...parts: string[]): string {
+  return parts.filter((f) => f != null && f.length > 0).join('_');
+}
+
 /**
  * Generates slug based on dataset category.
  *
@@ -120,39 +131,46 @@ export const commandStacSetup = command({
  */
 export function slugFromMetadata(metadata: SlugMetadata): string {
   const geographicDescription = metadata.geographicDescription || metadata.region;
-  const slug = slugify(metadata.date ? `${geographicDescription}_${metadata.date}` : geographicDescription);
 
-  if (
-    metadata.geospatialCategory === GeospatialDataCategories.AerialPhotos ||
-    metadata.geospatialCategory === GeospatialDataCategories.RuralAerialPhotos ||
-    metadata.geospatialCategory === GeospatialDataCategories.SatelliteImagery ||
-    metadata.geospatialCategory === GeospatialDataCategories.UrbanAerialPhotos
-  ) {
-    return `${slug}_${metadata.gsd}m`;
-  }
-  if (
-    metadata.geospatialCategory === GeospatialDataCategories.Dem ||
-    metadata.geospatialCategory === GeospatialDataCategories.Dsm ||
-    metadata.geospatialCategory === GeospatialDataCategories.DemHillshade ||
-    metadata.geospatialCategory === GeospatialDataCategories.DemHillshadeIgor
-  ) {
-    return slug;
-  }
-  if (metadata.geospatialCategory === GeospatialDataCategories.ScannedAerialPhotos) {
-    throw new Error(`Historic Imagery ${metadata.geospatialCategory} is out of scope for automated slug generation.`);
-  }
+  switch (metadata.geospatialCategory) {
+    case 'aerial-photos':
+    case 'rural-aerial-photos':
+    case 'satellite-imagery':
+    case 'urban-aerial-photos':
+      return formatParts(slugify(geographicDescription), metadata.date, `${metadata.gsd}m`);
 
-  throw new Error(`Slug can't be generated from collection as no matching category: ${metadata.geospatialCategory}.`);
+    case 'dem':
+    case 'dsm':
+    case 'dem-hillshade':
+    case 'dem-hillshade-igor':
+      return formatParts(slugify(geographicDescription), metadata.date);
+
+    case 'scanned-aerial-photos':
+      if (metadata.surveyId == null) throw new Error('Historical imagery needs a surveyId');
+      return formatParts(
+        slugify(geographicDescription),
+        metadata.surveyId.toLowerCase(),
+        metadata.date,
+        `${metadata.gsd}m`,
+      );
+
+    default:
+      throw new Error(
+        `Slug can't be generated from collection as no matching category: ${String(metadata.geospatialCategory)}.`,
+      );
+  }
 }
 
 /**
  * Format a STAC collection as a "startYear-endYear" or "startYear" in Pacific/Auckland time
+ * only if both "startYear" and "endYear" are defined.
  *
  * @param startYear start capture date
  * @param endYear end capture date
  * @returns the formatted slug dates
  */
-export function formatDate(startYear: string, endYear: string): string {
+export function formatDate(startYear?: string, endYear?: string): string {
+  if (startYear == null && endYear == null) return '';
   if (startYear === endYear) return startYear;
   return `${startYear}-${endYear}`;
 }

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -59,7 +59,7 @@ export const commandStacSetup = command({
     }),
 
     surveyId: option({
-      type: string,
+      type: optional(string),
       long: 'survey-id',
       description: 'Associated survey id, eg SN8066 or SNC20505',
     }),
@@ -104,7 +104,7 @@ export const commandStacSetup = command({
       logger.info({ duration: performance.now() - startTime, slug, collectionId }, 'StacSetup:Done');
     } else {
       const metadata: SlugMetadata = {
-        geospatialCategory: args.geospatialCategory,
+        geospatialCategory: args.geospatialCategory as GeospatialDataCategory,
         region: args.region,
         surveyId: args.surveyId,
         geographicDescription: args.geographicDescription,
@@ -170,7 +170,9 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
  * @returns the formatted slug dates
  */
 export function formatDate(startYear?: string, endYear?: string): string {
-  if (startYear == null && endYear == null) return '';
+  if (startYear == null || endYear == null) return '';
+  if (startYear.length === 0 || endYear.length === 0) return '';
+
   if (startYear === endYear) return startYear;
   return `${startYear}-${endYear}`;
 }


### PR DESCRIPTION
#### Motivation

We are still receiving more historical imagery we need to ensure we can continue to process the historical imagery


#### Modification

Add survey id to the list of optional arguments for stac-setup so that slugs can include the historical survery eg

```
west-coast_otago_sn8321_1984-1985_0.375m
west-coast_sn8534_1985-1986_0.375m
west-coast_sn9641_1997_0.75m
```

#### Verification

Unit tests