### PR TITLE
feat(stac-setup): support start dates

### DIFF
--- a/src/commands/stac-setup/README.md
+++ b/src/commands/stac-setup/README.md
@@ -8,18 +8,20 @@ stac-setup <options>
 
 ### Options
 
-| Usage                          | Description                                 | Options                          |
-| ------------------------------ | ------------------------------------------- | -------------------------------- |
-| --config <str>                 | Location of role configuration file         | optional                         |
-| --start-year <str>             | Start year of survey capture                | optional                         |
-| --end-year <str>               | End year of survey capture                  | optional                         |
-| --gsd <value>                  | GSD of dataset, e.g. 0.3                    |                                  |
-| --region <str>                 | Region of dataset                           |                                  |
-| --geographic-description <str> | Geographic description of dataset           |                                  |
-| --survey-id <str>              | Associated survey id, eg SN8066 or SNC20505 | optional                         |
-| --geospatial-category <str>    | Geospatial category of dataset              |                                  |
-| --odr-url <str>                | Open Data Registry URL of existing dataset  | optional                         |
-| --output <value>               | Where to store output files                 | default: file:///tmp/stac-setup/ |
+| Usage                          | Description                                               | Options                          |
+| ------------------------------ | --------------------------------------------------------- | -------------------------------- |
+| --config <str>                 | Location of role configuration file                       | optional                         |
+| --start-date <str>             | End date of survey capture (YYYY-MM-DD), eg 2023-01-01    | optional                         |
+| --start-year <str>             | Start year of survey capture, deprecated use --start-date | optional                         |
+| --end-date <str>               | End date of survey capture (YYYY-MM-DD), eg 2024-05-23    | optional                         |
+| --end-year <str>               | End year of survey capture, deprecated use --end-date     | optional                         |
+| --gsd <value>                  | GSD of dataset, e.g. 0.3                                  |                                  |
+| --region <str>                 | Region of dataset                                         |                                  |
+| --geographic-description <str> | Geographic description of dataset                         |                                  |
+| --survey-id <str>              | Associated survey id, eg SN8066 or SNC20505               | optional                         |
+| --geospatial-category <str>    | Geospatial category of dataset                            |                                  |
+| --odr-url <str>                | Open Data Registry URL of existing dataset                | optional                         |
+| --output <value>               | Where to store output files                               | default: file:///tmp/stac-setup/ |
 
 ### Flags
 

--- a/src/commands/stac-setup/__test__/stac.setup.test.ts
+++ b/src/commands/stac-setup/__test__/stac.setup.test.ts
@@ -22,8 +22,18 @@ describe('stac-setup', () => {
 
   const BaseArgs = {
     verbose: false,
+    startDate: undefined,
+    endDate: undefined,
+    endYear: undefined,
+    startYear: undefined,
     config: undefined,
     surveyId: undefined,
+    odrUrl: '',
+    output: new URL('memory://tmp/stac-setup/'),
+    gsd: '1',
+    region: 'gisborne',
+    geographicDescription: 'Wairoa',
+    geospatialCategory: 'dem',
   };
 
   it('should retrieve setup from collection', async () => {
@@ -111,6 +121,26 @@ describe('stac-setup', () => {
 
     const slug = await fsa.read('memory://tmp/stac-setup/linz-slug');
     assert.equal(String(slug), 'chatham-islands_sn8066_1982-1983_0.375m');
+  });
+
+  it('should error if startDate and startYear are both supplied', async () => {
+    const baseArgs = {
+      ...BaseArgs,
+      startYear: '1982',
+      startDate: '1982-01-01',
+    } as const;
+    const ret = await commandStacSetup.handler(baseArgs).catch((e) => String(e));
+    assert.equal(ret, 'Error: --start-date and --start-year are mutually exclusive');
+  });
+
+  it('should error if endDate and endYear are both supplied', async () => {
+    const baseArgs = {
+      ...BaseArgs,
+      endYear: '1982',
+      endDate: '1982-01-01',
+    } as const;
+    const ret = await commandStacSetup.handler(baseArgs).catch((e) => String(e));
+    assert.equal(ret, 'Error: --end-date and --end-year are mutually exclusive');
   });
 });
 
@@ -231,6 +261,11 @@ describe('formatDate', () => {
 
     assert.equal(formatDate('2023', undefined), '');
     assert.equal(formatDate('2023', ''), '');
+  });
+
+  it('should format full dates without timezone conversion', () => {
+    assert.equal(formatDate('2023-01-01T00:00:00.000Z', '2024-01-01T00:00:00.000Z'), '2023-2024');
+    assert.equal(formatDate('2023-01-01', '2024-01-01'), '2023-2024');
   });
 });
 


### PR DESCRIPTION
#### Motivation

With historical imagery processing we will need a way for being more specific with the dates as part of the setup, so to prepare for the upcoming historical imagery changes allow more specific dates to be supplied.

#### Modification

adds --start-date and --end-date that are mutually exclusive from their --start-year and --end-year that allow specifying the date as a `YYYY-MM-DD`

deprecate for --start-year and --end-year

#### Validation

Unit tests
