### PR TITLE
fix: harmonize hillshade odr paths TDE-1447

### DIFF
--- a/src/commands/generate-path/__test__/generate.path.test.ts
+++ b/src/commands/generate-path/__test__/generate.path.test.ts
@@ -34,7 +34,6 @@ describe('GeneratePathHillshade', () => {
       's3://nz-elevation/new-zealand/new-zealand-contour/dem-hillshade-igor_8m/2193/',
     );
   });
-
   it('Should match - hillshade 8m default', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-elevation',
@@ -46,7 +45,7 @@ describe('GeneratePathHillshade', () => {
     };
     assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand-contour/dem-hillshade_8m/2193/');
   });
-  it('Should match - hillshade combined igor', () => {
+  it('Should match - hillshade 1m igor', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-elevation',
       geospatialCategory: 'dem-hillshade-igor',
@@ -55,9 +54,9 @@ describe('GeneratePathHillshade', () => {
       gsd: 1,
       epsg: 2193,
     };
-    assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dem-hillshade-igor/2193/');
+    assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dem-hillshade-igor_1m/2193/');
   });
-  it('Should match - hillshade combined default', () => {
+  it('Should match - hillshade 1m default', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-elevation',
       geospatialCategory: 'dem-hillshade',
@@ -66,7 +65,7 @@ describe('GeneratePathHillshade', () => {
       gsd: 1,
       epsg: 2193,
     };
-    assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dem-hillshade/2193/');
+    assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dem-hillshade_1m/2193/');
   });
 });
 

--- a/src/commands/generate-path/path.generate.ts
+++ b/src/commands/generate-path/path.generate.ts
@@ -93,18 +93,10 @@ export function generatePath(metadata: PathMetadata): string {
   if (
     metadata.geospatialCategory === GeospatialDataCategories.Dem ||
     metadata.geospatialCategory === GeospatialDataCategories.Dsm ||
-    (metadata.gsd === 8 &&
-      (metadata.geospatialCategory === GeospatialDataCategories.DemHillshade ||
-        metadata.geospatialCategory === GeospatialDataCategories.DemHillshadeIgor))
-  ) {
-    return `s3://${metadata.targetBucketName}/${metadata.region}/${metadata.slug}/${metadata.geospatialCategory}_${metadata.gsd}m/${metadata.epsg}/`;
-  }
-
-  if (
     metadata.geospatialCategory === GeospatialDataCategories.DemHillshade ||
     metadata.geospatialCategory === GeospatialDataCategories.DemHillshadeIgor
   ) {
-    return `s3://${metadata.targetBucketName}/${metadata.region}/${metadata.slug}/${metadata.geospatialCategory}/${metadata.epsg}/`;
+    return `s3://${metadata.targetBucketName}/${metadata.region}/${metadata.slug}/${metadata.geospatialCategory}_${metadata.gsd}m/${metadata.epsg}/`;
   }
 
   throw new Error(


### PR DESCRIPTION
#### Motivation

`generate-path` had a special naming rule for creating hillshade from 8m DEM. As we are now publishing all intermediate hillshades (1m, 8m) this special case has become the default.
The different path for the _merged_ hillshade (without _`gsd`m) is not able to be automatically generated as it stands, and can now be pulled from `odr_url`.

#### Modification

Remove special case for creating hillshade ODR paths.

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [ ] Docs updated (not this level of detail in docs)
- [x] Issue linked in Title
