### PR TITLE
feat(basemaps): Create pull request for the DSM import into elevation.dsm.json config. BM-1245

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -287,11 +287,11 @@ export const basemapsCreatePullRequest = command({
 
     const git = new MakeCogGithub(layer.name, args.repository, args.ticket);
     if (configType === 'vector') {
-      await git.updateVectorTileSet(layer.name, layer, args.individual);
+      await git.updateVectorTileSet(layer, args.individual);
     } else if (configType === 'raster') {
-      await git.updateRasterTileSet(layer.name, layer, category, args.individual, region);
+      await git.updateRasterTileSet(layer, category, args.individual, region);
     } else if (configType === 'elevation') {
-      await git.updateElevationTileSet(layer.name, layer, args.individual, region);
+      await git.updateElevationTileSet(layer, args.individual, region);
     } else throw new Error(`Invalid Config File target: ${configType}`);
   },
 });

--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -81,7 +81,6 @@ export class MakeCogGithub {
    * Prepare and create pull request for the aerial tileset config
    */
   async updateRasterTileSet(
-    filename: string,
     layer: ConfigLayer,
     category: Category,
     individual: boolean,
@@ -89,7 +88,7 @@ export class MakeCogGithub {
   ): Promise<void> {
     const gh = new GithubApi(this.repository);
     const branch = `feat/bot-config-raster-${this.imagery}${this.ticketBranchSuffix}`;
-    const title = `config(raster): Add imagery ${this.imagery} to ${filename}${this.ticketCommitSuffix}`;
+    const title = `config(raster): Add imagery ${this.imagery} to ${layer.name} ${this.ticketCommitSuffix}`;
 
     // Clone the basemaps-config repo and checkout branch
     logger.info({ imagery: this.imagery }, 'GitHub: Get the master TileSet config file');
@@ -124,23 +123,18 @@ export class MakeCogGithub {
   /**
    * Prepare and create pull request for the elevation tileset config
    */
-  async updateElevationTileSet(
-    filename: string,
-    layer: ConfigLayer,
-    individual: boolean,
-    region: string | undefined,
-  ): Promise<void> {
+  async updateElevationTileSet(layer: ConfigLayer, individual: boolean, region: string | undefined): Promise<void> {
     const gh = new GithubApi(this.repository);
     const branch = `feat/bot-config-elevation-${this.imagery}${this.ticketBranchSuffix}`;
-    const title = `config(elevation): Add elevation ${this.imagery} to ${filename} config file.`;
+    const title = `config(elevation): Add elevation ${this.imagery} to ${layer.name} config file.`;
 
     let type;
-    if (filename.includes('_dsm_')) {
+    if (layer.name.includes('_dsm_')) {
       type = 'dsm';
-    } else if (filename.includes('_dem_')) {
+    } else if (layer.name.includes('_dem_')) {
       type = 'dem';
     } else {
-      throw new Error(`Invalid elevation type for ${filename}, must be dem or dsm.`);
+      throw new Error(`Invalid elevation type for ${layer.name}, must be dem or dsm.`);
     }
 
     // Clone the basemaps-config repo and checkout branch
@@ -166,7 +160,8 @@ export class MakeCogGithub {
   /**
    * Prepare and create pull request for the aerial tileset config
    */
-  async updateVectorTileSet(filename: string, layer: ConfigLayer, individual: boolean): Promise<void> {
+  async updateVectorTileSet(layer: ConfigLayer, individual: boolean): Promise<void> {
+    const filename = layer.name;
     const gh = new GithubApi(this.repository);
     const branch = `feat/bot-config-vector-${this.imagery}${this.ticketBranchSuffix}`;
     const title = `config(vector): Update the ${this.imagery} to ${filename} config file.`;


### PR DESCRIPTION
#### Motivation

We are not importing elevation dsm layers into basemaps. We want the create-pr can automatically creating pull requests for the dsm import and update the layer into `elevations.dsm.json`
https://github.com/linz/basemaps-config/pull/1065 

#### Modifications

- Check for `_dsm_` or `_dem_` from the `layer.name`, like `wellington_2013-2014_dsm_1m`.
   - Add individual ones into `elevation/dem/wellington_2013-2014_dem_1m.json` or `elevation/dsm/wellington_2013-2014_dsm_1m.json`.
   - Add combined into `elevation.json` for `dem` layer and `elevation.dsm.json` for `dsm` layer.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
