### PR TITLE
docs: improve tile-index-valitate documentation TDE-1403

### DIFF
--- a/src/commands/tileindex-validate/README.md
+++ b/src/commands/tileindex-validate/README.md
@@ -8,9 +8,9 @@ tileindex-validate <options> [...location]
 
 ### Arguments
 
-| Usage         | Description                  | Options |
-| ------------- | ---------------------------- | ------- |
-| [...location] | Location of the source files |         |
+| Usage         | Description                                                  | Options |
+| ------------- | ------------------------------------------------------------ | ------- |
+| [...location] | Location of the source files. Accepts multiple source paths. |         |
 
 ### Options
 

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -213,7 +213,11 @@ export const commandTileIndexValidate = command({
       defaultValueIsSerializable: true,
       defaultValue: () => false,
     }),
-    location: restPositionals({ type: string, displayName: 'location', description: 'Location of the source files' }),
+    location: restPositionals({
+      type: string,
+      displayName: 'location',
+      description: 'Location of the source files. Accepts multiple source paths.',
+    }),
   },
   async handler(args) {
     const startTime = performance.now();


### PR DESCRIPTION
#### Motivation

The documentation was not specifying that the command can accept multiple source.

#### Modification
- Amend the description

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
