### PR TITLE
feat: support national DSM hillshades TDE-1455

### DIFF
--- a/src/commands/generate-path/__test__/generate.path.test.ts
+++ b/src/commands/generate-path/__test__/generate.path.test.ts
@@ -21,7 +21,7 @@ describe('GeneratePathImagery', () => {
 });
 
 describe('GeneratePathHillshade', () => {
-  it('Should match - hillshade 8m igor', () => {
+  it('Should match - DEM hillshade 8m igor', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-elevation',
       geospatialCategory: 'dem-hillshade-igor',
@@ -35,7 +35,7 @@ describe('GeneratePathHillshade', () => {
       's3://nz-elevation/new-zealand/new-zealand-contour/dem-hillshade-igor_8m/2193/',
     );
   });
-  it('Should match - hillshade 8m default', () => {
+  it('Should match - DEM hillshade 8m default', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-elevation',
       geospatialCategory: 'dem-hillshade',
@@ -46,7 +46,7 @@ describe('GeneratePathHillshade', () => {
     };
     assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand-contour/dem-hillshade_8m/2193/');
   });
-  it('Should match - hillshade 1m igor', () => {
+  it('Should match - DEM hillshade 1m igor', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-elevation',
       geospatialCategory: 'dem-hillshade-igor',
@@ -57,7 +57,7 @@ describe('GeneratePathHillshade', () => {
     };
     assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dem-hillshade-igor_1m/2193/');
   });
-  it('Should match - hillshade 1m default', () => {
+  it('Should match - DEM hillshade 1m default', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-elevation',
       geospatialCategory: 'dem-hillshade',
@@ -67,6 +67,28 @@ describe('GeneratePathHillshade', () => {
       epsg: 2193,
     };
     assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dem-hillshade_1m/2193/');
+  });
+  it('Should match - DSM hillshade 1m igor', () => {
+    const metadata: PathMetadata = {
+      targetBucketName: 'nz-elevation',
+      geospatialCategory: 'dsm-hillshade-igor',
+      region: 'new-zealand',
+      slug: 'new-zealand',
+      gsd: 1,
+      epsg: 2193,
+    };
+    assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dsm-hillshade-igor_1m/2193/');
+  });
+  it('Should match - DSM hillshade 1m default', () => {
+    const metadata: PathMetadata = {
+      targetBucketName: 'nz-elevation',
+      geospatialCategory: 'dsm-hillshade',
+      region: 'new-zealand',
+      slug: 'new-zealand',
+      gsd: 1,
+      epsg: 2193,
+    };
+    assert.equal(generatePath(metadata), 's3://nz-elevation/new-zealand/new-zealand/dsm-hillshade_1m/2193/');
   });
 });
 

--- a/src/commands/generate-path/path.generate.ts
+++ b/src/commands/generate-path/path.generate.ts
@@ -95,7 +95,9 @@ export function generatePath(metadata: PathMetadata): string {
     metadata.geospatialCategory === GeospatialDataCategories.Dem ||
     metadata.geospatialCategory === GeospatialDataCategories.Dsm ||
     metadata.geospatialCategory === GeospatialDataCategories.DemHillshade ||
-    metadata.geospatialCategory === GeospatialDataCategories.DemHillshadeIgor
+    metadata.geospatialCategory === GeospatialDataCategories.DemHillshadeIgor ||
+    metadata.geospatialCategory === GeospatialDataCategories.DsmHillshade ||
+    metadata.geospatialCategory === GeospatialDataCategories.DsmHillshadeIgor
   ) {
     return `s3://${metadata.targetBucketName}/${metadata.region}/${metadata.slug}/${metadata.geospatialCategory}_${metadata.gsd}m/${metadata.epsg}/`;
   }

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -158,6 +158,8 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
     case 'dsm':
     case 'dem-hillshade':
     case 'dem-hillshade-igor':
+    case 'dsm-hillshade':
+    case 'dsm-hillshade-igor':
       return formatParts(slugify(geographicDescription), metadata.date);
 
     case 'scanned-aerial-photos':

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -18,6 +18,8 @@ export const GeospatialDataCategories = {
   Dsm: 'dsm',
   DemHillshade: 'dem-hillshade',
   DemHillshadeIgor: 'dem-hillshade-igor',
+  DsmHillshade: 'dsm-hillshade',
+  DsmHillshadeIgor: 'dsm-hillshade-igor',
 } as const;
 
 export type GeospatialDataCategory = (typeof GeospatialDataCategories)[keyof typeof GeospatialDataCategories];


### PR DESCRIPTION
#### Motivation

As a Basemaps user
I want national DSM hillshades (1m and unspecified resolution, standard and igor)
So that I can view/accentuate terrain detail in a variety of basemaps.

#### Modification

Added appropriate constants to `metadata.ts`, `stac.setup.ts` and `path.generate.ts`.
  DsmHillshade: 'dsm-hillshade',
  DsmHillshadeIgor: 'dsm-hillshade-igor',

#### Checklist

- [x] Tests updated
- [ ] Docs updated (docs not this detailed)
- [x] Issue linked in Title
