### PR TITLE
fix: update from .js to .ts files TDE-1474

### DIFF
--- a/src/commands/copy/copy.ts
+++ b/src/commands/copy/copy.ts
@@ -54,7 +54,7 @@ export const commandCopy = command({
   async handler(args) {
     registerCli(this, args);
 
-    const workerUrl = new URL('./copy-worker.js', import.meta.url);
+    const workerUrl = new URL('./copy-worker.ts', import.meta.url);
     const pool = new WorkerRpcPool<CopyContract>(args.concurrency, workerUrl);
 
     const stats = { copied: 0, copiedBytes: 0, retries: 0, skipped: 0, skippedBytes: 0 };

--- a/src/commands/identify-updated-items/__test__/identify.updated.items.test.ts
+++ b/src/commands/identify-updated-items/__test__/identify.updated.items.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 
 import { fsa } from '@chunkd/fs';
 
-import type { FileListEntry } from '../../../utils/filelist.js';
+import type { FileListEntry } from '../../../utils/filelist.ts';
 import { commandIdentifyUpdatedItems } from '../identify.updated.items.ts';
 
 /**


### PR DESCRIPTION
#### Motivation

Copy workflow was broken since change to Node23

#### Modification

Updated copy worker to call `.ts` instead of `.js` and one other reference to a .js project file in tests.

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
