### PR TITLE
build: correct path for test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "tsc",
     "docs": "node src/readme/readme.generate.ts",
     "lint": "npx eslint . --ignore-path .gitignore",
-    "test": "node --test"
+    "test": "node --test 'src/**/*.test.ts'"
   },
   "publishConfig": {
     "access": "restricted"


### PR DESCRIPTION
#### Motivation

in Node 23.9 `node --test` would find all `**/*.test.ts` files and run them, this caused a number of issues for some repositories so node revered this change, in node 23.11 (current) `node --test` no longer finds `**/*.test.ts` to run, so none of the tests are running in this repository

#### Modification

force node to find `src/**/*.test.ts` and run them when using `node --test`

#### Verification

Ran locally on node 23.9 and 23.11.