### PR TITLE
feat: add linz/coastal repo TDE-1456

### DIFF
--- a/src/commands/stac-github-import/README.md
+++ b/src/commands/stac-github-import/README.md
@@ -8,14 +8,14 @@ stac-github-import <options>
 
 ### Options
 
-| Usage                 | Description                                            | Options               |
-| --------------------- | ------------------------------------------------------ | --------------------- |
-| --config <str>        | Location of role configuration file                    | optional              |
-| --source <value>      | Source location of the collection.json file            |                       |
-| --target <value>      | Target location for the collection.json file           |                       |
-| --repo-name <value>   | One of 'linz/elevation', 'linz/imagery'                | default: linz/imagery |
-| --copy-option <value> | One of '--force', '--no-clobber', '--force-no-clobber' | default: --no-clobber |
-| --ticket <str>        | Associated JIRA ticket e.g. AIP-74                     | default:              |
+| Usage                 | Description                                             | Options               |
+| --------------------- | ------------------------------------------------------- | --------------------- |
+| --config <str>        | Location of role configuration file                     | optional              |
+| --source <value>      | Source location of the collection.json file             |                       |
+| --target <value>      | Target location for the collection.json file            |                       |
+| --repo-name <value>   | One of 'linz/coastal', 'linz/elevation', 'linz/imagery' | default: linz/imagery |
+| --copy-option <value> | One of '--force', '--no-clobber', '--force-no-clobber'  | default: --no-clobber |
+| --ticket <str>        | Associated JIRA ticket e.g. AIP-74                      | default:              |
 
 ### Flags
 

--- a/src/commands/stac-github-import/stac.github.import.ts
+++ b/src/commands/stac-github-import/stac.github.import.ts
@@ -22,6 +22,7 @@ const imageryRepo = 'linz/imagery';
  * Valid repositories, mapped to the email address used for the PR author
  */
 export const BotEmails: Record<string, string> = {
+  'linz/coastal': 'hydrosurvey@linz.govt.nz',
   'linz/elevation': 'elevation@linz.govt.nz',
   [imageryRepo]: 'imagery@linz.govt.nz',
 };
@@ -75,15 +76,9 @@ export const commandStacGithubImport = command({
     if (botEmail == null) throw new Error(`${args.repoName} is not a valid GitHub repository`);
 
     const basemapsConfigLinkURL = new URL('config-url', args.source);
-    // TODO When Basemaps supports Elevation config as part of the standardising workflow, remove this try catch block
-    // https://toitutewhenua.atlassian.net/browse/BM-985
     const prBody: string[] = [];
-    try {
-      const basemapsConfigLink = await fsa.read(basemapsConfigLinkURL.href);
-      prBody.push(`**Basemaps preview link for Visual QA:** [Basemaps 🗺️](${String(basemapsConfigLink)})`);
-    } catch (e) {
-      if (args.repoName === imageryRepo) throw e;
-    }
+    const basemapsConfigLink = await fsa.read(basemapsConfigLinkURL.href);
+    prBody.push(`**Basemaps preview link for Visual QA:** [Basemaps 🗺️](${String(basemapsConfigLink)})`);
     prBody.push(`**ODR destination path:** \`${args.target.href}\``);
 
     // Load information from the template inside the repo


### PR DESCRIPTION
#### Motivation

There is a new ODR bucket `s3://nz-coastal` that uses the https://github.com/linz/argo-tasks GitHub repository for provisioning datasets.

#### Modification

Add the `linz/coastal` repository and associated `linz-li-bot` GitHub account email address.
Remove out of date try/catch block that is no longer needed now that Basemaps support Elevation configs.

#### Checklist

- [ ] Tests updated
- [x] Docs updated
- [x] Issue linked in Title
