### PR TITLE
ci: use node v23 for linz-action-typescript

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
-          node-version: 20.x
+          node-version: 23.x
 
       - name: Download actionlint
         run: docker build --tag actionlint - < .github/workflows/actionlint.dockerfile


### PR DESCRIPTION
#### Motivation

The node version has been forgotten to be upgraded to use the `linz-action-typescript` causing npm test scripts [to fail](https://github.com/linz/argo-tasks/actions/runs/14697476826/job/41241186400).

#### Modification

- use node 23.x to call `linz-action-typescript`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
