### PR TITLE
build: upgrade to node24 as it is the next lts

### DIFF
--- a/.github/workflows/pull-request-container.yml
+++ b/.github/workflows/pull-request-container.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
-          node-version: 23.x
+          node-version: 24.x
 
       - name: Setup GIT version
         id: version

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
-          node-version: 23.x
+          node-version: 24.x
 
       - name: Generate Readme
         run: |
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
-          node-version: 23.x
+          node-version: 24.x
 
       - name: Download actionlint
         run: docker build --tag actionlint - < .github/workflows/actionlint.dockerfile

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
-          node-version: 23.x
+          node-version: 24.x
 
       - name: Setup GIT version
         id: version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-slim@sha256:b89d748ea010f4d276c9d45c750fa5f371cef3fcc7486f739f07e5aad1b998a8
+FROM node:24-slim@sha256:f403f3b5054f8f35ebe8dd167e0c608945a8fd992f3d278d2a8652b58b80dc92
 
 RUN apt-get update && apt-get install openssh-client git -y
 


### PR DESCRIPTION
#### Motivation

node23 was only used as it is added support for running typescript directly, this pr changes to a more stable release channel

#### Modification

swap to node24

#### Verification

CI/CD to verify build and deploy, ran container locally

