### PR TITLE
fix: allow reading from complex 🦄🌈 URLs TDE-1504

### DIFF
--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -126,7 +126,7 @@ export function tryParseUrl(loc: string): URL {
  */
 export function urlToString(u: URL): string {
   if (u.protocol === 'file:') return fileURLToPath(u);
-  return u.href;
+  return decodeURI(u.href);
 }
 
 /**

--- a/src/commands/identify-updated-items/identify.updated.items.ts
+++ b/src/commands/identify-updated-items/identify.updated.items.ts
@@ -8,7 +8,7 @@ import { CliInfo } from '../../cli.info.ts';
 import { logger } from '../../log.ts';
 import { combinePaths, splitPaths } from '../../utils/chunk.ts';
 import { ConcurrentQueue } from '../../utils/concurrent.queue.ts';
-import { createFileList } from '../../utils/filelist.ts';
+import type { FileListEntry } from '../../utils/filelist.ts';
 import { registerCli, verbose } from '../common.ts';
 
 interface LinzItemLink extends StacLink {
@@ -142,15 +142,9 @@ export const commandIdentifyUpdatedItems = command({
       }
       logger.trace({ itemId }, `identifyUpdatedItems:Skipping ${itemId} because sources match`);
     }
-    const tilesToProcess = createFileList(
-      new Map(
-        Object.entries(itemsToProcess).map(([key, value]) => [
-          key,
-          value.map((item) => item.href.replace(/\.json$/, '.tiff')),
-        ]),
-      ),
-      true,
-    );
+    const tilesToProcess: FileListEntry[] = Object.entries(itemsToProcess).map(([key, value]) => {
+      return { output: key, input: value.map((item) => item.href.replace(/\.json$/, '.tiff')), includeDerived: true };
+    });
 
     const fileListPath = '/tmp/identify-updated-items/file-list.json';
     await fsa.write(fileListPath, JSON.stringify(tilesToProcess));

--- a/src/commands/mapsheet-coverage/mapsheet.coverage.ts
+++ b/src/commands/mapsheet-coverage/mapsheet.coverage.ts
@@ -14,7 +14,7 @@ import type { StacCollection, StacItem } from 'stac-ts';
 import { CliInfo } from '../../cli.info.ts';
 import { logger } from '../../log.ts';
 import { getPacificAucklandYearMonthDay } from '../../utils/date.ts';
-import { createFileList } from '../../utils/filelist.ts';
+import type { FileListEntry } from '../../utils/filelist.ts';
 import { hashStream } from '../../utils/hash.ts';
 import { MapSheet } from '../../utils/mapsheet.ts';
 import { config, registerCli, tryParseUrl, Url, UrlFolder, urlToString, verbose } from '../common.ts';
@@ -282,7 +282,10 @@ export const commandMapSheetCoverage = command({
     }
 
     // List of tiles to be created, and files from which to create
-    const tilesToProcess = createFileList(mapSheets, true);
+    const tilesToProcess: FileListEntry[] = [];
+    for (const [sheetName, inputs] of mapSheets) {
+      tilesToProcess.push({ output: sheetName, input: inputs, includeDerived: true });
+    }
 
     const fileListPath = new URL('file-list.json', args.output);
     await fsa.write(urlToString(fileListPath), JSON.stringify(tilesToProcess));

--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -140,7 +140,7 @@ describe('tiffLocation', () => {
   });
 });
 
-describe.only('validate', () => {
+describe('validate', () => {
   const memory = new FsMemory();
 
   before(() => {

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -361,7 +361,7 @@ export function groupByTileName(tiffs: TiffLocation[]): Map<string, TiffLocation
 
 export interface TiffLocation {
   /** Location to the image */
-  source: string;
+  source: URL;
   /** bbox, [minX, minY, maxX, maxY] */
   bbox: BBox;
   /** EPSG code of the tiff if found */
@@ -439,7 +439,7 @@ export async function extractTiffLocations(
         // }
         return {
           bbox: targetBbox,
-          source: tiff.source.url.href,
+          source: tiff.source.url,
           tileNames: covering,
           epsg: tiff.images[0]?.epsg,
           bands: await extractBandInformation(tiff),

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -341,7 +341,7 @@ function validateConsistentBands(locs: TiffLocation[]): string[] {
         logger.error({ path: v.source, bands: v.bands.join(',') }, 'TileIndex:Bands:Heterogenous');
       }
 
-      throw new Error(`heterogenous bands: ${currentBands} vs ${firstBand} from: ${locs[0]?.source}`);
+      throw new Error(`heterogenous bands: ${currentBands} vs ${firstBand} from: ${locs[0]?.source.href}`);
     }
   }
   return firstBands;

--- a/src/utils/__test__/filelist.test.ts
+++ b/src/utils/__test__/filelist.test.ts
@@ -6,11 +6,22 @@ import type { FileListEntry } from '../filelist.ts';
 import { createFileList } from '../filelist.ts';
 
 describe('createFileList', () => {
-  const locationTestOne: TiffLocation = { bands: [], bbox: [0, 0, 0, 0], tileNames: [], source: 'input1' };
-  const locationTestTwo: TiffLocation = { bands: [], bbox: [0, 0, 0, 0], tileNames: [], source: 'input2' };
-  const entries = new Map<string, TiffLocation[] | string[]>([
+  const complexUrl = `memory://username@input2:3030/🦄🌈.tiff?query=foo#@1234`;
+  const locationTestOne: TiffLocation = {
+    bands: [],
+    bbox: [0, 0, 0, 0],
+    tileNames: [],
+    source: new URL('memory://input1'),
+  };
+  const locationTestTwo: TiffLocation = {
+    bands: [],
+    bbox: [0, 0, 0, 0],
+    tileNames: [],
+    source: new URL(complexUrl),
+  };
+  const entries = new Map<string, TiffLocation[]>([
     ['output1', [locationTestOne, locationTestTwo]],
-    ['output2', ['input3', 'input4']],
+    ['output2', [locationTestTwo]],
   ]);
 
   it('should create a file list from TiffLocation and string inputs with derived inputs set based on input flag', () => {
@@ -20,12 +31,12 @@ describe('createFileList', () => {
       assert.deepEqual(result, [
         {
           output: 'output1',
-          input: ['input1', 'input2'],
+          input: ['memory://input1', complexUrl],
           includeDerived: includeDerived,
         },
         {
           output: 'output2',
-          input: ['input3', 'input4'],
+          input: [complexUrl],
           includeDerived: includeDerived,
         },
       ]);
@@ -33,7 +44,7 @@ describe('createFileList', () => {
   });
 
   it('should handle empty entries map', () => {
-    const entries = new Map<string, TiffLocation[] | string[]>();
+    const entries = new Map<string, TiffLocation[]>();
     const includeDerived = false;
 
     const result: FileListEntry[] = createFileList(entries, includeDerived);

--- a/src/utils/filelist.ts
+++ b/src/utils/filelist.ts
@@ -1,7 +1,10 @@
+import { urlToString } from '../commands/common.ts';
 import type { TiffLocation } from '../commands/tileindex-validate/tileindex.validate.ts';
 
 export type FileListEntry = {
+  /** output file name eg "AS21_10000_0103" */
   output: string;
+  /** List of input files */
   input: string[];
   includeDerived: boolean;
 };
@@ -13,21 +16,14 @@ export type FileListEntry = {
  * @param entries output tiles that will be generated and list of associated input tiles.
  * @param includeDerived whether the STAC file should include derived_from links to the input tiles.
  */
-export function createFileList(
-  entries: Map<string, TiffLocation[] | string[]>,
-  includeDerived: boolean,
-): FileListEntry[] {
-  return [...entries.keys()].map((key) => {
-    const value = entries.get(key);
-    if (!value) {
-      throw new Error(`Key "${key}" not found in entries map`);
-    }
-    const processedInput = value.map((item) => (typeof item === 'string' ? item : item.source));
-
-    return {
+export function createFileList(entries: Map<string, TiffLocation[]>, includeDerived: boolean): FileListEntry[] {
+  const output: FileListEntry[] = [];
+  for (const [key, value] of entries) {
+    output.push({
       output: key,
-      input: processedInput,
+      input: value.map((item) => urlToString(item.source)),
       includeDerived,
-    };
-  });
+    });
+  }
+  return output;
 }


### PR DESCRIPTION
#### Motivation

Some input locations have very complex URLs, for example `s3://blacha-test/🦄 🌈/input.tiff`, when converting this location to a URL the path is URL encoded with `%`, when requesting URLs via the AWS SDK, the AWS SDK will automatically encode the URL again, causing a duplication of encoding. For example `%20` turns into `%2520` then S3 will fail to return the right object.

#### Modification

Add unit tests to validate our input and outputs to ensure URLS are not encoded for input and output
Add unit tests to validate commands can handle utf8 inputs 🦄🌈🦄🌈

#### Verification

ran unit tests + ran CLI locally