### PR TITLE
fix: stac-setup `--geographic-description` should be optional TDE-1510

### DIFF
--- a/src/commands/stac-setup/README.md
+++ b/src/commands/stac-setup/README.md
@@ -17,7 +17,7 @@ stac-setup <options>
 | --end-year <str>               | End year of survey capture, deprecated use --end-date     | optional                         |
 | --gsd <value>                  | GSD of dataset, e.g. 0.3                                  |                                  |
 | --region <str>                 | Region of dataset                                         |                                  |
-| --geographic-description <str> | Geographic description of dataset                         |                                  |
+| --geographic-description <str> | Geographic description of dataset                         | optional                         |
 | --survey-id <str>              | Associated survey id, eg SN8066 or SNC20505               | optional                         |
 | --geospatial-category <str>    | Geospatial category of dataset                            |                                  |
 | --odr-url <str>                | Open Data Registry URL of existing dataset                | optional                         |

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -65,7 +65,7 @@ export const commandStacSetup = command({
     }),
 
     geographicDescription: option({
-      type: string,
+      type: optional(string),
       long: 'geographic-description',
       description: 'Geographic description of dataset',
     }),


### PR DESCRIPTION
#### Motivation

Geographic description is an optional metadata. 

#### Modification

- set `--geographic-description` as optional

#### Verification

Ran without passing `--geographic-description`
