### PR TITLE
fix: package information is not logged when command has not started TDE-1511

### DIFF
--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -5,7 +5,6 @@ import { boolean, flag, option, optional, string } from 'cmd-ts';
 import pLimit from 'p-limit';
 import { fileURLToPath, pathToFileURL } from 'url';
 
-import { CliInfo } from '../cli.info.ts';
 import { registerFileSystem } from '../fs.register.ts';
 import { logger, registerLogger } from '../log.ts';
 import { isArgo } from '../utils/argo.ts';
@@ -34,7 +33,7 @@ export function registerCli(cli: { name: string }, args: { verbose?: boolean; co
   registerLogger(args);
   registerFileSystem(args);
 
-  logger.info({ package: CliInfo, cli: cli.name, args, isArgo: isArgo() }, 'Cli:Start');
+  logger.info({ cli: cli.name, args, isArgo: isArgo() }, 'Cli:Start');
 }
 
 /** Trim any extra special characters from the cli parser */

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { cmd } from './commands/index.ts';
 import { logger } from './log.ts';
 
 const startTime = performance.now();
-logger.info({ package: CliInfo }, 'Cli:Info');
+logger.info({ package: CliInfo, args: process.argv.slice(2) }, 'Cli:Info');
 run(cmd, process.argv.slice(2))
   .then(() => {
     logger.debug({ duration: performance.now() - startTime }, 'Command:Done');

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,12 @@ process.env['AWS_NODEJS_CONNECTION_REUSE_ENABLED'] = '1';
 
 import { run } from 'cmd-ts';
 
+import { CliInfo } from './cli.info.ts';
 import { cmd } from './commands/index.ts';
 import { logger } from './log.ts';
 
 const startTime = performance.now();
+logger.info({ package: CliInfo }, 'Cli:Info');
 run(cmd, process.argv.slice(2))
   .then(() => {
     logger.debug({ duration: performance.now() - startTime }, 'Command:Done');


### PR DESCRIPTION
#### Motivation

If a command fails to start (for example, missing arguments), the package information (for example, `"package":{"package":"@linzjs/argo-tasks","version":"v4.14.2","hash":"e8dbf80c51b7a2baf61b22eec49de7072c812223","buildId":""}`) is not logged. Without this information, it makes it difficult to reproduce.

#### Modification

- Move package info logs before the command run

#### Verification

Local test
