### PR TITLE
fix(basemaps): Fix the topographic pull request creation to support topgraphic-v2. BM-1203

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -65,6 +65,8 @@ export function parseTargetUrl(target: string, offset: 0 | 1): targetInfo {
   // Get filename for vector target
   if (target.endsWith('.tar.co')) {
     const filename = splits.at(-1);
+    if (filename == null) throw new Error(`Invalid cotar filename for vector map ${filename}.`);
+    const name = filename.replace('.tar.co', ''); // Layer name for vector map is same as the cotar filename
     return { bucket, epsg, name, filename };
   } else {
     return { bucket, epsg, name };
@@ -143,7 +145,7 @@ async function parseVectorTargetInfo(target: string): Promise<{ name: string; ti
   }
   if (title == null) throw new Error(`Failed to get title from collection.json.`);
 
-  return { name: name, epsg: epsg.code, title };
+  return { name, epsg: epsg.code, title };
 }
 
 /**

--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -174,7 +174,7 @@ export class MakeCogGithub {
       // Github create pull request
       await this.createTileSetPullRequest(gh, branch, title, tileSetPath, newTileSet);
     } else {
-      const tileSetPath = fsa.joinAll('config', 'tileset', `topographic.json`);
+      const tileSetPath = fsa.joinAll('config', 'tileset', `${filename}.json`);
       const tileSetContent = await gh.getContent(tileSetPath);
       if (tileSetContent == null) throw new Error(`Failed to get config topographic from config repo.`);
       // update the existing tileset


### PR DESCRIPTION
### Motivation

For the topographic config file with the following format, and we will move to versions tag at the end of json filename.
[For example](https://github.com/linz/basemaps-config/blob/master/config/tileset/topographic-v2.json): 
`config/tileset/topographic-v2.json`
->
```
{
  "type": "vector",
  "id": "ts_topographic-v2",
  "title": "New Zealand Topographic Vector Map",
  "maxZoom": 15,
  "format": "pbf",
  "layers": [
    {
      "3857": "s3://linz-basemaps/vector/3857/topographic/01JP1H9Z44EX3TPRJD6GNZBV58/topographic-v2.tar.co",
      "name": "topographic-v2",
      "title": "Topographic V2"
    }
  ]
}
```
So we need use the filename `topographic-v2.tar.co` to parse the name for pull request creation.

### Modifications

Get the vector layer name from filename instead of the path

### Verification
Local tested.
![image](https://github.com/user-attachments/assets/c834c7cf-68cd-4865-88ce-efaa8edd5f6a)
