### PR TITLE
feat: generate path for scanned-aerial-photos TDE-1522

### DIFF
--- a/src/commands/generate-path/__test__/generate.path.test.ts
+++ b/src/commands/generate-path/__test__/generate.path.test.ts
@@ -18,6 +18,17 @@ describe('GeneratePathImagery', () => {
     };
     assert.equal(generatePath(metadata), 's3://nz-imagery/auckland/auckland_2023_0.3m/rgb/2193/');
   });
+  it('Should match - scanned aerial photos from slug', () => {
+    const metadata: PathMetadata = {
+      targetBucketName: 'nz-imagery',
+      geospatialCategory: 'scanned-aerial-photos',
+      region: 'waikato',
+      slug: 'waikato_sn11978_1992-1995_0.4m',
+      gsd: 0.4,
+      epsg: 2193,
+    };
+    assert.equal(generatePath(metadata), 's3://nz-imagery/waikato/waikato_sn11978_1992-1995_0.4m/rgb/2193/');
+  });
 });
 
 describe('GeneratePathHillshade', () => {
@@ -127,19 +138,6 @@ describe('GeneratePathGeospatialDataCategories', () => {
     assert.throws(() => {
       generatePath(metadata);
     }, Error("Path can't be generated from collection as no matching category for not-a-valid-category."));
-  });
-  it('Should error - does not support historical aerial photos', () => {
-    const metadata: PathMetadata = {
-      targetBucketName: 'nz-imagery',
-      geospatialCategory: 'scanned-aerial-photos',
-      region: 'wellington',
-      slug: 'napier_2017-2018_0.05m',
-      gsd: 0.5,
-      epsg: 2193,
-    };
-    assert.throws(() => {
-      generatePath(metadata);
-    }, Error('Historic Imagery scanned-aerial-photos is out of scope for automated path generation.'));
   });
 });
 

--- a/src/commands/generate-path/path.generate.ts
+++ b/src/commands/generate-path/path.generate.ts
@@ -78,15 +78,11 @@ export const commandGeneratePath = command({
  * @returns
  */
 export function generatePath(metadata: PathMetadata): string {
-  if (metadata.geospatialCategory === GeospatialDataCategories.ScannedAerialPhotos) {
-    // nb: Historic Imagery is out of scope as survey number is not yet recorded in collection metadata
-    throw new Error(`Historic Imagery ${metadata.geospatialCategory} is out of scope for automated path generation.`);
-  }
-
   if (
     metadata.geospatialCategory === GeospatialDataCategories.UrbanAerialPhotos ||
     metadata.geospatialCategory === GeospatialDataCategories.RuralAerialPhotos ||
-    metadata.geospatialCategory === GeospatialDataCategories.SatelliteImagery
+    metadata.geospatialCategory === GeospatialDataCategories.SatelliteImagery ||
+    metadata.geospatialCategory === GeospatialDataCategories.ScannedAerialPhotos
   ) {
     return `s3://${metadata.targetBucketName}/${metadata.region}/${metadata.slug}/rgb/${metadata.epsg}/`;
   }


### PR DESCRIPTION
### Motivation

As the slug generation enable creating the slug for the scanned-aerial-photos, the path generation should too.

### Modifications

- Allow path generation for the scanned-aerial-photo category

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

automated tests
<!-- TODO: Say how you tested your changes. -->
