### PR TITLE
feat(basemaps): Add support for NZTM vector tiles in PR creation

### DIFF
--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -131,7 +131,6 @@ async function parseVectorTargetInfo(target: string): Promise<{ name: string; ti
   if (filename == null || !filename.endsWith('.tar.co')) {
     throw new Error(`Invalid cotar filename for vector map ${filename}.`);
   }
-  if (epsg !== Epsg.Google) throw new Error(`Unsupported epsg code ${epsg.code} for vector map.`);
   // Try to get the title
   const collectionPath = target.replace(filename, 'collection.json');
   const collection = await fsa.readJson<StacCollection>(collectionPath);

--- a/src/commands/basemaps-github/create-pr.ts
+++ b/src/commands/basemaps-github/create-pr.ts
@@ -131,6 +131,7 @@ async function parseVectorTargetInfo(target: string): Promise<{ name: string; ti
   if (filename == null || !filename.endsWith('.tar.co')) {
     throw new Error(`Invalid cotar filename for vector map ${filename}.`);
   }
+
   // Try to get the title
   const collectionPath = target.replace(filename, 'collection.json');
   const collection = await fsa.readJson<StacCollection>(collectionPath);


### PR DESCRIPTION
### Motivation

We are starting to create vector map in NZTM projection and we could remove the check for Webmecator only.

### Modifications

Remove the check for vector map epsg code in the url

### Verification
Tested in argo. 
https://argo.linzaccess.com/workflows/argo/test-basemaps-vector-etl-shortbread-pvrdg?tab=workflow&nodeId=test-basemaps-vector-etl-shortbread-pvrdg-2737806755&uid=7425f2b1-d218-48e4-ba7a-d174b2ecbe42
