### PR TITLE
fix: identify-updated-items should return ordered input based on collection order TDE-1588

### DIFF
--- a/src/commands/identify-updated-items/identify.updated.items.ts
+++ b/src/commands/identify-updated-items/identify.updated.items.ts
@@ -143,7 +143,12 @@ export const commandIdentifyUpdatedItems = command({
       logger.trace({ itemId }, `identifyUpdatedItems:Skipping ${itemId} because sources match`);
     }
     const tilesToProcess: FileListEntry[] = Object.entries(itemsToProcess).map(([key, value]) => {
-      return { output: key, input: value.map((item) => item.href.replace(/\.json$/, '.tiff')), includeDerived: true };
+      const tiffInputs = value.map((item) => item.href.replace(/\.json$/, '.tiff'));
+      return {
+        output: key,
+        input: sortInputsBySourceOrder(tiffInputs, sourceCollectionUrls),
+        includeDerived: true,
+      };
     });
 
     const fileListPath = '/tmp/identify-updated-items/file-list.json';
@@ -159,3 +164,18 @@ export const commandIdentifyUpdatedItems = command({
     );
   },
 });
+
+/**
+ * Sorts the input file paths by their order in the source collections.
+ *
+ * @param inputs The input file paths to sort.
+ * @param sourceCollections The source collections to use for sorting.
+ * @returns The sorted input file paths.
+ */
+function sortInputsBySourceOrder(inputs: string[], sourceCollections: string[]): string[] {
+  return inputs.sort((a, b) => {
+    const indexA = sourceCollections.findIndex((src) => a.includes(src.replace('/collection.json', '')));
+    const indexB = sourceCollections.findIndex((src) => b.includes(src.replace('/collection.json', '')));
+    return indexA - indexB;
+  });
+}


### PR DESCRIPTION
### Motivation

The order of the `input` was random (see multiple automated test runs failing for both `should only add modified items to file-list.json` and `should add all source items if no target collection is provided`). It needs to follow the order of the collection passed in `--source-collections`.

### Modifications

- Explicitly sort the `input` arrays to match the order of `--source-collections` as provided by the user, ensuring that files from the first collection always appear first, then the second, etc.

### Verification

Run the automated tests locally a bunch of times.
