### PR TITLE
fix: decode url passed from CSV report TDE-1603

### DIFF
--- a/src/commands/verify-restore/__test__/verify.restore.test.ts
+++ b/src/commands/verify-restore/__test__/verify.restore.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import type { HeadObjectCommandOutput } from '@aws-sdk/client-s3';
 
 import {
+  decodeFormUrlEncoded,
   fetchPendingRestoredObjectPaths,
   fetchResultKeysFromReport,
   isRestoreCompleted,
@@ -87,16 +88,16 @@ describe('fetchPendingRestoredObjectPaths', () => {
 
 describe('parseReportResult', () => {
   it('parses CSV string into ReportResult[]', () => {
-    const csv = 'b,k,v,ts,ec,hs,Successful\nb2,k2,v2,ts2,ec2,hs2,Failed';
+    const csv = 'b,k,v,ts,hs,ec,Successful\nb2,k2,v2,ts2,hs2,ec2,Failed';
     const results = parseReportResult(csv);
-    assert.deepEqual(results, [
+    assert.deepStrictEqual(results, [
       {
         Bucket: 'b',
         Key: 'k',
         VersionId: 'v',
         TaskStatus: 'ts',
-        ErrorCode: 'ec',
         HTTPStatusCode: 'hs',
+        ErrorCode: 'ec',
         ResultMessage: 'Successful',
       },
       {
@@ -104,8 +105,8 @@ describe('parseReportResult', () => {
         Key: 'k2',
         VersionId: 'v2',
         TaskStatus: 'ts2',
-        ErrorCode: 'ec2',
         HTTPStatusCode: 'hs2',
+        ErrorCode: 'ec2',
         ResultMessage: 'Failed',
       },
     ]);
@@ -134,5 +135,30 @@ describe('isRestoreCompleted', () => {
       $metadata: { httpStatusCode: 200, requestId: '', extendedRequestId: '', cfId: '' },
     };
     assert.throws(() => isRestoreCompleted(headObjectOutput), /undefined/);
+  });
+});
+
+describe('decodeFormUrlEncoded', () => {
+  it('should decode a standard URL-encoded string', () => {
+    assert.strictEqual(decodeFormUrlEncoded('hello%20world'), 'hello world');
+  });
+
+  it('should decode plus signs as spaces', () => {
+    assert.strictEqual(decodeFormUrlEncoded('hello+world'), 'hello world');
+  });
+
+  it('should decode mixed encoding', () => {
+    assert.strictEqual(decodeFormUrlEncoded('file%2Bname+with+spaces%21'), 'file+name with spaces!');
+  });
+
+  it('should return the same string if no encoding is present', () => {
+    assert.strictEqual(decodeFormUrlEncoded('plainstring'), 'plainstring');
+  });
+
+  it('should decode complex encoded strings', () => {
+    assert.strictEqual(
+      decodeFormUrlEncoded('%2Fpath%2Fto%2Bfile+with+spaces%2Band%2Bplus'),
+      '/path/to+file with spaces+and+plus',
+    );
   });
 });

--- a/src/commands/verify-restore/verify.restore.ts
+++ b/src/commands/verify-restore/verify.restore.ts
@@ -172,8 +172,8 @@ export function parseReportResult(result: string): ReportResult[] {
       Key: parts[1] ?? '',
       VersionId: parts[2] ?? '',
       TaskStatus: parts[3] ?? '',
-      ErrorCode: parts[4] ?? '',
-      HTTPStatusCode: parts[5] ?? '',
+      HTTPStatusCode: parts[4] ?? '',
+      ErrorCode: parts[5] ?? '',
       ResultMessage: parts[6] ?? '',
     };
   });
@@ -188,9 +188,10 @@ export function parseReportResult(result: string): ReportResult[] {
  */
 async function headS3Object(path: { Bucket: string; Key: string }): Promise<HeadObjectCommandOutput> {
   try {
+    const objectKey = decodeFormUrlEncoded(path.Key);
     const headObjectOutput: HeadObjectCommandOutput = await (
-      fsa.get(`s3://${path.Bucket}/${path.Key}`, 'r') as FsAwsS3V3
-    ).client.send(new HeadObjectCommand({ Bucket: path.Bucket, Key: path.Key }));
+      fsa.get(`s3://${path.Bucket}/${objectKey}`, 'r') as FsAwsS3V3
+    ).client.send(new HeadObjectCommand({ Bucket: path.Bucket, Key: objectKey }));
     logger.info({ path, headObjectOutput }, 'VerifyRestore:HeadObject');
     return headObjectOutput;
   } catch (error) {
@@ -225,4 +226,13 @@ async function markReportDone(reportPath: URL): Promise<void> {
   await fsa.write(donePath.toString(), await fsa.read(reportPath.toString()));
   await fsa.delete(reportPath.toString());
   logger.info({ reportPath, donePath }, 'VerifyRestore:MarkedReportDone');
+}
+/**
+ * Decodes a URL-encoded string.
+ *
+ * @param key - The URL-encoded string to decode.
+ * @returns The decoded string.
+ */
+export function decodeFormUrlEncoded(key: string): string {
+  return decodeURIComponent(key.replace(/\+/g, ' '));
 }


### PR DESCRIPTION
### Motivation

S3 Batch Operations report results CSV encode the object keys. They need to be decoded before fetching the objects.

### Modifications

decode the URL
also fix a parsing issue

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Automated tests
<!-- TODO: Say how you tested your changes. -->
