### PR TITLE
fix: `ResultMessage` should be trimmed TDE-1554

### DIFF
--- a/src/commands/verify-restore/__test__/verify.restore.test.ts
+++ b/src/commands/verify-restore/__test__/verify.restore.test.ts
@@ -84,6 +84,21 @@ describe('fetchPendingRestoredObjectPaths', () => {
     ];
     assert.throws(() => fetchPendingRestoredObjectPaths(entries), { message: /not successful/ });
   });
+
+  it('treats ResultMessage with trailing \\r as successful', () => {
+    const entries = [
+      {
+        Bucket: 'b',
+        Key: 'k',
+        VersionId: '',
+        TaskStatus: '',
+        ErrorCode: '',
+        HTTPStatusCode: '',
+        ResultMessage: 'Successful\r',
+      },
+    ];
+    assert.deepStrictEqual(fetchPendingRestoredObjectPaths(entries), [{ Bucket: 'b', Key: 'k' }]);
+  });
 });
 
 describe('parseReportResult', () => {

--- a/src/commands/verify-restore/verify.restore.ts
+++ b/src/commands/verify-restore/verify.restore.ts
@@ -142,7 +142,7 @@ export function fetchResultKeysFromReport(report: ManifestReport): string[] {
  * @returns An array of objects containing the Bucket and Key of each restored object.
  */
 export function fetchPendingRestoredObjectPaths(resultEntries: ReportResult[]): { Bucket: string; Key: string }[] {
-  const notSuccessfulRequests = resultEntries.filter((row: ReportResult) => row.ResultMessage !== 'Successful');
+  const notSuccessfulRequests = resultEntries.filter((row: ReportResult) => row.ResultMessage.trim() !== 'Successful');
   if (notSuccessfulRequests.length) {
     throw new Error(
       `Some restore requests are not successful: ${notSuccessfulRequests.map((row) => row.Key).join(', ')}`,
@@ -157,7 +157,11 @@ export function fetchPendingRestoredObjectPaths(resultEntries: ReportResult[]): 
 
 /**
  * Parses the CSV report result string into an array of ReportResult.
- * "ReportSchema": "Bucket, Key, VersionId, TaskStatus, ErrorCode, HTTPStatusCode, ResultMessage"
+ *
+ * FIXME: The ReportSchema provided by AWS
+ * ("ReportSchema": "Bucket, Key, VersionId, TaskStatus, ErrorCode, HTTPStatusCode, ResultMessage")
+ * is wrong and the actual CSV format is:
+ * "ReportSchema": "Bucket, Key, VersionId, TaskStatus, HTTPStatusCode, ErrorCode, ResultMessage"
  *
  * @param result - The CSV result string containing restored object paths and statuses.
  * @returns An array of ReportResult.


### PR DESCRIPTION
### Motivation

`ResultMessage` can contain a carriage return character `\r`.
<!-- TODO: Say why you made your changes. -->

### Modifications

trim `ResultMessage`
Update doc related to AWS providing wrong CSV schema
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

manual tests
automated tests

<!-- TODO: Say how you tested your changes. -->
