### PR TITLE
chore: end to end unit test with create-manifest+copy

### DIFF
--- a/src/commands/copy/__test__/copy.manifest.test.ts
+++ b/src/commands/copy/__test__/copy.manifest.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert';
+import { rm } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+import { fsa } from '@chunkd/fs';
+import { FsMemory } from '@chunkd/source-memory';
+
+import type { ActionCopy } from '../../../utils/actions.ts';
+import { urlToString } from '../../common.ts';
+import type { CommandCreateManifestArgs } from '../../create-manifest/create-manifest.ts';
+import { commandCreateManifest } from '../../create-manifest/create-manifest.ts';
+import { commandCopy, type CommandCopyArgs } from '../copy.ts';
+
+describe('createManifest.Copy.E2E', () => {
+  /**
+   * As this test uses sub processes we cannot just write to memory://
+   * we need to use an actual file system
+   */
+  const sourceLocation = pathToFileURL('./.test/');
+
+  const memory = new FsMemory();
+  beforeEach(() => {
+    fsa.register('memory://', memory);
+    // action-location assumes s3
+    fsa.register('s3://', memory);
+
+    memory.files.clear();
+  });
+
+  afterEach(async () => {
+    await rm(sourceLocation, { recursive: true, force: true });
+  });
+
+  const baseManifestArgs: CommandCreateManifestArgs = {
+    config: undefined,
+    verbose: false,
+    flatten: false,
+    transform: undefined,
+    include: undefined,
+    exclude: undefined,
+    groupSize: undefined,
+    group: undefined,
+    limit: undefined,
+    output: '',
+    target: '',
+    source: [],
+  };
+  const baseCopyArgs: CommandCopyArgs = {
+    config: undefined,
+    verbose: false,
+    force: false,
+    noClobber: false,
+    forceNoClobber: false,
+    fixContentType: false,
+    compress: false,
+    decompress: false,
+    deleteSource: false,
+    concurrency: 1,
+    manifest: [],
+  };
+
+  it('should create a manifest and copy some files', async () => {
+    const mkPath = (str: string): string => urlToString(new URL(str, sourceLocation));
+    await fsa.write(mkPath(`source/🟥/🦄 🌈.txt`), Buffer.alloc(1));
+    await fsa.write(mkPath(`source/🟥/🦄 🌈.json`), Buffer.alloc(2));
+    await fsa.write(mkPath(`source/🟥/🟧/🌈.pdf`), Buffer.alloc(3));
+    await fsa.write(mkPath(`source/🟥/🟧/🌈.tiff`), Buffer.alloc(4));
+
+    // TODO do we need a "action" logic and a compressed file logic?
+    process.env['ACTION_PATH'] = `memory://actions/🟥/actions/`;
+
+    await commandCreateManifest.handler({
+      ...baseManifestArgs,
+      group: 2,
+      source: [mkPath('source/🟥')],
+      target: mkPath('target/'),
+      output: './.test/🦄 🌈.manifest.json',
+    });
+
+    const basePath = urlToString(sourceLocation);
+
+    const manifest = await fsa.readJson<string[]>('./.test/🦄 🌈.manifest.json');
+
+    assert.equal(manifest.length, 2);
+    const firstManifestUrl = manifest[0] as string;
+    const firstManifest = await fsa.readJson<ActionCopy>(firstManifestUrl);
+    assert.equal(firstManifest.action, 'copy');
+    assert.deepEqual(
+      firstManifest.parameters.manifest.map((m) => {
+        return { source: m.source.slice(basePath.length), target: m.target.slice(basePath.length) };
+      }),
+      [
+        {
+          source: 'source/🟥/🟧/🌈.pdf',
+          target: 'target/🟧/🌈.pdf',
+        },
+        {
+          source: 'source/🟥/🟧/🌈.tiff',
+          target: 'target/🟧/🌈.tiff',
+        },
+      ],
+    );
+
+    await commandCopy.handler({ ...baseCopyArgs, manifest: [firstManifestUrl] });
+
+    async function getAllFiles(): Promise<[string, number][]> {
+      const files = await fsa.toArray(fsa.details(basePath));
+      const filesShort: [string, number][] = files.map((m) => [m.path.slice(basePath.length), m.size ?? 0]);
+      filesShort.sort((a, b) => a[0].localeCompare(b[0]));
+
+      return filesShort;
+    }
+
+    assert.deepEqual(await getAllFiles(), [
+      ['🦄 🌈.manifest.json', 197],
+      ['source/🟥/🦄 🌈.json', 2],
+      ['source/🟥/🦄 🌈.txt', 1],
+      ['source/🟥/🟧/🌈.pdf', 3],
+      ['source/🟥/🟧/🌈.tiff', 4],
+
+      // Only the first part of the source has been copied
+      ['target/🟧/🌈.pdf', 3],
+      ['target/🟧/🌈.tiff', 4],
+    ]);
+
+    await commandCopy.handler({ ...baseCopyArgs, force: true, manifest });
+
+    assert.deepEqual(await getAllFiles(), [
+      ['🦄 🌈.manifest.json', 197],
+      ['source/🟥/🦄 🌈.json', 2],
+      ['source/🟥/🦄 🌈.txt', 1],
+      ['source/🟥/🟧/🌈.pdf', 3],
+      ['source/🟥/🟧/🌈.tiff', 4],
+
+      ['target/🦄 🌈.json', 2],
+      ['target/🦄 🌈.txt', 1],
+      ['target/🟧/🌈.pdf', 3],
+      ['target/🟧/🌈.tiff', 4],
+    ]);
+  });
+});

--- a/src/commands/copy/copy-helpers.ts
+++ b/src/commands/copy/copy-helpers.ts
@@ -1,5 +1,6 @@
 import type { FileInfo } from '@chunkd/core';
 import { fsa } from '@chunkd/fs';
+import { FsFile } from '@chunkd/source-file';
 
 import { logger } from '../../log.ts';
 import { tryHead } from '../../utils/file.head.ts';
@@ -216,7 +217,15 @@ export async function determineTargetFileOperation(
 export async function verifyTargetFile(target: string, expectedSize: number, expectedHash: string): Promise<boolean> {
   const targetReadBack = await tryHead(target);
   const targetSize = targetReadBack?.size;
-  const targetHash = targetReadBack?.metadata?.[HashKey];
+  const targetFs = fsa.get(target, 'rw');
+
+  let targetHash = targetReadBack?.metadata?.[HashKey];
+
+  // TODO: Local file system does not support metadata so assume hash is correct
+  if (FsFile.is(targetFs)) {
+    targetHash = '0';
+    expectedHash = '0';
+  }
 
   const targetVerified = targetSize === expectedSize && targetHash === expectedHash;
   if (!targetVerified) logger.fatal({ target, expectedHash, targetHash, expectedSize, targetSize }, 'Copy:Failed');

--- a/src/commands/copy/copy.ts
+++ b/src/commands/copy/copy.ts
@@ -4,6 +4,7 @@ import { boolean, command, flag, number, option, restPositionals, string } from 
 import { performance } from 'perf_hooks';
 import * as z from 'zod';
 
+import type { CommandArguments } from '../../__test__/type.util.ts';
 import { CliInfo } from '../../cli.info.ts';
 import { logger, logId } from '../../log.ts';
 import type { ActionCopy } from '../../utils/actions.ts';
@@ -140,3 +141,5 @@ export const commandCopy = command({
     logger.info({ copyStats: stats, duration: performance.now() - startTime }, 'File:Copy:Done');
   },
 });
+
+export type CommandCopyArgs = CommandArguments<typeof commandCopy>;

--- a/src/commands/create-manifest/__test__/create-manifest.test.ts
+++ b/src/commands/create-manifest/__test__/create-manifest.test.ts
@@ -4,6 +4,7 @@ import { gunzipSync } from 'node:zlib';
 
 import { fsa } from '@chunkd/fs';
 import { FsMemory } from '@chunkd/source-memory';
+import { parse } from 'cmd-ts';
 
 import type { CommandArguments } from '../../../__test__/type.util.ts';
 import type { SourceTarget } from '../create-manifest.ts';
@@ -106,6 +107,21 @@ describe('createManifest', () => {
     });
   });
 
+  it('should parse required options', async () => {
+    const parsed = (await parse(
+      commandCreateManifest,
+      [
+        ['--output', 'memory://output/🦄 🌈.json'],
+        ['--target', 'memory:/target/🟪/🦄 🌈.txt'],
+        'memory://source/🟥/',
+      ].flat(),
+    )) as { _tag: 'ok'; value: CommandCreateManifestArgs };
+    assert.equal(parsed._tag, 'ok');
+    assert.deepEqual(parsed.value.source, ['memory://source/🟥/']);
+    assert.deepEqual(parsed.value.target, 'memory:/target/🟪/🦄 🌈.txt');
+    assert.deepEqual(parsed.value.output, 'memory://output/🦄 🌈.json');
+  });
+
   const baseArgs: CommandCreateManifestArgs = {
     config: undefined,
     verbose: false,
@@ -122,13 +138,13 @@ describe('createManifest', () => {
   };
 
   it('should generate a output', async () => {
-    await fsa.write(`memory://some-bucket/🦄/🦄 🌈.txt`, Buffer.alloc(1));
-    await fsa.write(`memory://some-bucket/🌈/🦄 🌈.txt`, Buffer.alloc(0));
+    await fsa.write(`memory://source/🟥/🦄 🌈.txt`, Buffer.alloc(1));
+    await fsa.write(`memory://source/🟥/🦄 🌈.json`, Buffer.alloc(0));
 
     await commandCreateManifest.handler({
       ...baseArgs,
-      source: ['memory://some-bucket/'],
-      target: 'memory://target/🦄 🌈/',
+      source: ['memory://source/🟥/'],
+      target: 'memory://target/🟪/',
       output: 'memory://output/🦄 🌈.json',
     });
 
@@ -142,8 +158,8 @@ describe('createManifest', () => {
 
     assert.deepEqual(firstBytes, [
       {
-        source: 'memory://some-bucket/🦄/🦄 🌈.txt',
-        target: 'memory://target/🦄 🌈/🦄/🦄 🌈.txt',
+        source: 'memory://source/🟥/🦄 🌈.txt',
+        target: 'memory://target/🟪/🦄 🌈.txt',
       },
     ]);
   });

--- a/src/commands/create-manifest/create-manifest.ts
+++ b/src/commands/create-manifest/create-manifest.ts
@@ -4,6 +4,7 @@ import { createHash } from 'crypto';
 import path from 'path';
 import { gzipSync } from 'zlib';
 
+import type { CommandArguments } from '../../__test__/type.util.ts';
 import { CliInfo } from '../../cli.info.ts';
 import { getActionLocation } from '../../utils/action.storage.ts';
 import type { ActionCopy } from '../../utils/actions.ts';
@@ -120,3 +121,5 @@ export function validatePaths(source: string, target: string): void {
   }
   throw new Error(`Path Mismatch - source: ${source}, target: ${target}`);
 }
+
+export type CommandCreateManifestArgs = CommandArguments<typeof commandCreateManifest>;


### PR DESCRIPTION
### Motivation

Increase test coverage by running a full flow of create-manifest + copy 

### Modifications

adds a end to end test combining the create-manifest + copy commands.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
