### PR TITLE
fix: ongoing-request=false is not parsed correctly TDE-1554

### DIFF
--- a/src/commands/verify-restore/__test__/verify.restore.test.ts
+++ b/src/commands/verify-restore/__test__/verify.restore.test.ts
@@ -134,7 +134,7 @@ describe('parseReportResult', () => {
 describe('isRestoreCompleted', () => {
   it('returns true if Restore is ongoing-request="false"', async () => {
     const headObjectOutput: HeadObjectCommandOutput = {
-      Restore: 'ongoing-request="false"',
+      Restore: 'ongoing-request="false, , expiry-date="Sat, 16 Aug 2025 00:00:00 GMT""',
       $metadata: { httpStatusCode: 200, requestId: '', extendedRequestId: '', cfId: '' },
     };
     const fileInfo: FileInfo<HeadObjectCommandOutput> = {

--- a/src/commands/verify-restore/__test__/verify.restore.test.ts
+++ b/src/commands/verify-restore/__test__/verify.restore.test.ts
@@ -134,7 +134,7 @@ describe('parseReportResult', () => {
 describe('isRestoreCompleted', () => {
   it('returns true if Restore is ongoing-request="false"', async () => {
     const headObjectOutput: HeadObjectCommandOutput = {
-      Restore: 'ongoing-request="false", expiry-date="Sat, 16 Aug 2025 00:00:00 GMT"',
+      Restore: 'ongoing-request="false, , expiry-date="Sat, 16 Aug 2025 00:00:00 GMT""',
       $metadata: { httpStatusCode: 200, requestId: '', extendedRequestId: '', cfId: '' },
     };
     const fileInfo: FileInfo<HeadObjectCommandOutput> = {

--- a/src/commands/verify-restore/__test__/verify.restore.test.ts
+++ b/src/commands/verify-restore/__test__/verify.restore.test.ts
@@ -134,7 +134,7 @@ describe('parseReportResult', () => {
 describe('isRestoreCompleted', () => {
   it('returns true if Restore is ongoing-request="false"', async () => {
     const headObjectOutput: HeadObjectCommandOutput = {
-      Restore: 'ongoing-request="false", expiry-date="Sat, 16 Aug 2025 00:00:00 GMT""',
+      Restore: 'ongoing-request="false", expiry-date="Sat, 16 Aug 2025 00:00:00 GMT"',
       $metadata: { httpStatusCode: 200, requestId: '', extendedRequestId: '', cfId: '' },
     };
     const fileInfo: FileInfo<HeadObjectCommandOutput> = {

--- a/src/commands/verify-restore/__test__/verify.restore.test.ts
+++ b/src/commands/verify-restore/__test__/verify.restore.test.ts
@@ -134,7 +134,7 @@ describe('parseReportResult', () => {
 describe('isRestoreCompleted', () => {
   it('returns true if Restore is ongoing-request="false"', async () => {
     const headObjectOutput: HeadObjectCommandOutput = {
-      Restore: 'ongoing-request="false, , expiry-date="Sat, 16 Aug 2025 00:00:00 GMT""',
+      Restore: 'ongoing-request="false", expiry-date="Sat, 16 Aug 2025 00:00:00 GMT""',
       $metadata: { httpStatusCode: 200, requestId: '', extendedRequestId: '', cfId: '' },
     };
     const fileInfo: FileInfo<HeadObjectCommandOutput> = {


### PR DESCRIPTION
### Motivation

AWS returns additional information in the `Restore` field such as the expiry date but the system checks exact match for `ongoing-request=false`. This causes the restore check to return `false` even when the restore was actually completed.

### Modifications

- use `includes()` instead of strict equality
- minor refactor

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Manual and automated tests
<!-- TODO: Say how you tested your changes. -->
