### PR TITLE
fix: register https and http FS for all commands. TDE-1637

### DIFF
--- a/src/commands/stac-validate/stac.validate.ts
+++ b/src/commands/stac-validate/stac.validate.ts
@@ -1,4 +1,4 @@
-import { fsa, FsHttp } from '@chunkd/fs';
+import { fsa } from '@chunkd/fs';
 import type { DefinedError, ValidateFunction } from 'ajv';
 import Ajv from 'ajv';
 import { fastFormats } from 'ajv-formats/dist/formats.js';
@@ -60,8 +60,6 @@ export const commandStacValidate = command({
   },
 
   async handler(args) {
-    fsa.register('https://', new FsHttp());
-
     registerCli(this, args);
 
     logger.info('StacValidation:Start');

--- a/src/fs.register.ts
+++ b/src/fs.register.ts
@@ -1,7 +1,7 @@
 import { setTimeout } from 'node:timers/promises';
 
 import { S3Client } from '@aws-sdk/client-s3';
-import { fsa } from '@chunkd/fs';
+import { fsa, FsHttp } from '@chunkd/fs';
 import type { AwsCredentialConfig } from '@chunkd/fs-aws';
 import { AwsS3CredentialProvider, FsAwsS3 } from '@chunkd/fs-aws';
 import type { BuildMiddleware, FinalizeRequestMiddleware, MetadataBearer } from '@smithy/types';
@@ -120,7 +120,8 @@ function splitConfig(x: string): string[] {
 /** Register the S3 file system with chunkd/fsa */
 export function registerFileSystem(opts: { config?: string }): FsAwsS3 {
   const s3Fs = setupS3FileSystem(new FsAwsS3(new S3Client()));
-
+  fsa.register('https://', new FsHttp());
+  fsa.register('http://', new FsHttp());
   fsa.register('s3://', s3Fs);
 
   const configPath = opts.config ?? process.env['AWS_ROLE_CONFIG_PATH'];


### PR DESCRIPTION
### Motivation

Workflows / argo tasks commands are not able to access files via https.

### Modifications

Register http(s) filesystem by default.

### Verification

Unit tests
manual workflow runs