### PR TITLE
fix: mapsheet coverage identifies all items as new TDE-1641

### DIFF
--- a/src/commands/mapsheet-coverage/mapsheet.coverage.ts
+++ b/src/commands/mapsheet-coverage/mapsheet.coverage.ts
@@ -351,7 +351,10 @@ async function compareCreation(
         if (needsToBeCreated) return;
 
         const sourceFile = sourceFiles[index];
-        if (sourceFile == null || item.href !== basename(sourceFile.pathname.replace('.tiff', '.json'))) {
+        if (
+          sourceFile == null ||
+          item.href !== replaceUrlPathPattern(sourceFile, RegExp('\\.tiff?$', 'i'), '.json').href
+        ) {
           logger.debug({ sheetCode, source: item.href }, 'MapSheetCoverage:Compare:source-difference');
           needsToBeCreated = true;
           return;
@@ -365,7 +368,7 @@ async function compareCreation(
         }
 
         // TODO: to improve performance further we could use the source collection.json as it contains all the item checksums
-        const sourceItemHash = await hashQueue(() => hashStream(fsa.readStream(sourceFile)));
+        const sourceItemHash = await hashQueue(() => hashStream(fsa.readStream(fsa.toUrl(item.href))));
         logger.trace(
           { source: item.href, hash: sourceItemHash, isOk: sourceItemHash === item['file:checksum'] },
           'MapSheetCoverage:Compare:checksum',


### PR DESCRIPTION
### Motivation

mapsheet-coverage incorrectly identifies all items as new.

### Modifications

Fix string comparison (remove "basename") and hash the correct file (STAC Item, not TIFF asset)

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
manual local test run 
`node src/index.ts mapsheet-coverage --verbose --location https://raw.githubusercontent.com/linz/basemaps-config/master/config/tileset/elevation.json --epsg-code 2193 --compare=s3://nz-elevation/new-zealand/new-zealand/dem_1m/2193/collection.json`