### PR TITLE
fix: file copy filter applies to filename only TDE-1642

### DIFF
--- a/src/utils/__test__/filter.test.ts
+++ b/src/utils/__test__/filter.test.ts
@@ -12,39 +12,123 @@ describe('AsyncFilter', () => {
     };
   }
 
+  it('should respect our default filters', async () => {
+    const gen = makeGenerator([
+      's3://bucket/path/to/flat/AS12.tiff',
+      's3://bucket/path/to/flat/AS13.tiff',
+      's3://bucket/path/to/flat/AT12.tiff',
+      's3://bucket/path/to/flat/AT13.tiff',
+      's3://bucket/path/to/flat/AS12.json',
+      's3://bucket/path/to/flat/AS13.json',
+      's3://bucket/path/to/flat/AT12.json',
+      's3://bucket/path/to/flat/AT13.json',
+      's3://bucket/path/to/flat/AS12.tfw',
+      's3://bucket/path/to/flat/AS12.prj',
+      's3://bucket/path/to/flat/AS13.tfw',
+      's3://bucket/path/to/flat/AT12.prj',
+      's3://bucket/path/to/flat/README.txt',
+      's3://bucket/path/to/flat/collection.json',
+      's3://bucket/path/to/flat/capture-area.geojson',
+      's3://bucket/path/to/flat/capture-dates.geojson',
+      's3://bucket/path/to/flat/notcapture-dates.geojson',
+    ]);
+    const expectedResults = [
+      's3://bucket/path/to/flat/AS12.tiff',
+      's3://bucket/path/to/flat/AS13.tiff',
+      's3://bucket/path/to/flat/AT12.tiff',
+      's3://bucket/path/to/flat/AT13.tiff',
+      's3://bucket/path/to/flat/AS12.json',
+      's3://bucket/path/to/flat/AS13.json',
+      's3://bucket/path/to/flat/AT12.json',
+      's3://bucket/path/to/flat/AT13.json',
+      's3://bucket/path/to/flat/AS12.tfw',
+
+      's3://bucket/path/to/flat/AS13.tfw',
+
+      's3://bucket/path/to/flat/capture-area.geojson',
+      's3://bucket/path/to/flat/capture-dates.geojson',
+    ].map((f) => {
+      return { url: fsa.toUrl(f) };
+    });
+
+    const result = await fsa.toArray(
+      asyncFilter(gen(), {
+        include: '\\.tiff?$|\\.json$|\\.tfw$|/capture-area\\.geojson$|/capture-dates\\.geojson$',
+        exclude: 'collection.json$',
+      }),
+    );
+    assert.deepEqual(result, expectedResults);
+  });
   it('should include all', async () => {
-    const gen = makeGenerator(['a.tiff', 'b.tiff', 'c.tiff']);
+    const gen = makeGenerator([
+      'file:///path/to/file/a.tiff',
+      'file:///path/to/file/b.tiff',
+      'file:///path/to/file/c.tiff',
+    ]);
     const result = await fsa.toArray(asyncFilter(gen()));
     assert.equal(result.length, 3);
   });
 
   it('should match include exact', async () => {
-    const gen = makeGenerator(['a.tiff', 'b.tiff', 'c.tiff']);
+    const gen = makeGenerator([
+      'file:///path/to/file/a.tiff',
+      'file:///path/to/file/b.tiff',
+      'file:///path/to/file/c.tiff',
+    ]);
+    const result = await fsa.toArray(asyncFilter(gen(), { include: 'file:///path/to/file/a.tiff' }));
+    assert.deepEqual(result, [{ url: fsa.toUrl('file:///path/to/file/a.tiff') }]);
+  });
+
+  it('should match include partial', async () => {
+    const gen = makeGenerator([
+      'file:///path/to/file/a.tiff',
+      'file:///path/to/file/b.tiff',
+      'file:///path/to/file/c.tiff',
+    ]);
     const result = await fsa.toArray(asyncFilter(gen(), { include: 'a.tiff' }));
-    assert.deepEqual(result, [{ url: fsa.toUrl('a.tiff') }]);
+    assert.deepEqual(result, [{ url: fsa.toUrl('file:///path/to/file/a.tiff') }]);
   });
 
   it('should match include regex', async () => {
-    const gen = makeGenerator(['a.tiff', 'ba.tiff', 'ca.tiff']);
-    const result = await fsa.toArray(asyncFilter(gen(), { include: '^a' }));
-    assert.deepEqual(result, [{ url: fsa.toUrl('a.tiff') }]);
+    const gen = makeGenerator([
+      'file:///path/to/file/a.tiff',
+      'file:///path/to/file/ba.tiff',
+      'file:///path/to/file/ca.tiff',
+    ]);
+    const result = await fsa.toArray(asyncFilter(gen(), { include: '/a' }));
+    assert.deepEqual(result, [{ url: fsa.toUrl('file:///path/to/file/a.tiff') }]);
   });
 
   it('should exclude', async () => {
-    const gen = makeGenerator(['a.tiff', 'ba.tiff', 'ca.tiff']);
-    const result = await fsa.toArray(asyncFilter(gen(), { exclude: '^a' }));
-    assert.deepEqual(result, [{ url: fsa.toUrl('ba.tiff') }, { url: fsa.toUrl('ca.tiff') }]);
+    const gen = makeGenerator([
+      'file:///path/to/file/a.tiff',
+      'file:///path/to/file/ba.tiff',
+      'file:///path/to/file/ca.tiff',
+    ]);
+    const result = await fsa.toArray(asyncFilter(gen(), { exclude: '/a' }));
+    assert.deepEqual(result, [
+      { url: fsa.toUrl('file:///path/to/file/ba.tiff') },
+      { url: fsa.toUrl('file:///path/to/file/ca.tiff') },
+    ]);
   });
 
   it('should include and exclude', async () => {
-    const gen = makeGenerator(['a.tiff', 'ba.prj', 'ca.tiff']);
-    const result = await fsa.toArray(asyncFilter(gen(), { exclude: '^a', include: '.tiff$' }));
-    assert.deepEqual(result, [{ url: fsa.toUrl('ca.tiff') }]);
+    const gen = makeGenerator([
+      'file:///path/to/file/a.tiff',
+      'file:///path/to/file/ba.prj',
+      'file:///path/to/file/ca.tiff',
+    ]);
+    const result = await fsa.toArray(asyncFilter(gen(), { exclude: '/a', include: '.tiff$' }));
+    assert.deepEqual(result, [{ url: fsa.toUrl('file:///path/to/file/ca.tiff') }]);
   });
 
   it('should include exclude case insensitive', async () => {
-    const gen = makeGenerator(['A.tiff', 'BA.prj', 'CA.TIFF']);
-    const result = await fsa.toArray(asyncFilter(gen(), { exclude: '^a', include: '.tiff$' }));
-    assert.deepEqual(result, [{ url: fsa.toUrl('CA.TIFF') }]);
+    const gen = makeGenerator([
+      'file:///path/to/file/A.tiff',
+      'file:///path/to/file/BA.prj',
+      'file:///path/to/file/CA.TIFF',
+    ]);
+    const result = await fsa.toArray(asyncFilter(gen(), { exclude: '/a', include: '.tiff$' }));
+    assert.deepEqual(result, [{ url: fsa.toUrl('file:///path/to/file/CA.TIFF') }]);
   });
 });

--- a/src/utils/chunk.ts
+++ b/src/utils/chunk.ts
@@ -17,7 +17,7 @@ export async function* asyncFilter<T extends FileSizeInfo>(
   const include = opts?.include ? new RegExp(opts.include.toLowerCase(), 'i') : true;
   const exclude = opts?.exclude ? new RegExp(opts.exclude.toLowerCase(), 'i') : undefined;
   for await (const f of source) {
-    const testPath = f.url.href.toLowerCase();  // using .href instead of .pathname to match full URL including hostname (bucket)
+    const testPath = f.url.href.toLowerCase(); // using url.href instead of url.pathname to match full URL including hostname (bucket)
     if (exclude && exclude.test(testPath)) continue;
     if (include === true) yield f;
     else if (include.test(testPath)) yield f;


### PR DESCRIPTION
### Motivation

create-manifest did not include the `capture-area.geojson` or `capture-dates.geojson` files although the following include and exclude expressions were included:
`include: \.tiff?$|\.json$|\.tfw$|/capture-area\.geojson$|/capture-dates\.geojson$`
`exclude: collection.json$`

The missing files are copied successfully if the include expression is changed to:
`\.tiff?$|\.json$|\.tfw$|capture-area\.geojson$|capture-dates\.geojson$`
although the following does not work:
`\.tiff?$|\.json$|\.tfw$|\/capture-area\.geojson$|\/capture-dates\.geojson$`
### Modifications

Compare filter against full `href` of the URL, instead of `basename(pathname)`. 
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification
Additional unit tests.