### PR TITLE
fix: accept aerial-photos as category TDE-1650

### DIFF
--- a/src/commands/generate-path/__test__/generate.path.test.ts
+++ b/src/commands/generate-path/__test__/generate.path.test.ts
@@ -24,6 +24,18 @@ describe('GeneratePathImagery', () => {
     };
     assert.equal(generatePath(metadata), 's3://nz-imagery/auckland/auckland_2023_0.3m/rgb/2193/');
   });
+  it('Should match - generic aerial photos from slug', () => {
+    const metadata: PathMetadata = {
+      targetBucketName: 'nz-imagery',
+      geospatialCategory: 'aerial-photos',
+      region: 'auckland',
+      slug: 'auckland_2023_0.3m',
+      gsd: 0.3,
+      epsg: 2193,
+    };
+    assert.equal(generatePath(metadata), 's3://nz-imagery/auckland/auckland_2023_0.3m/rgb/2193/');
+  });
+
   it('Should match - scanned aerial photos from slug', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-imagery',

--- a/src/commands/generate-path/path.generate.ts
+++ b/src/commands/generate-path/path.generate.ts
@@ -77,6 +77,7 @@ export const commandGeneratePath = command({
  */
 export function generatePath(metadata: PathMetadata): string {
   if (
+    metadata.geospatialCategory === GeospatialDataCategories.AerialPhotos ||
     metadata.geospatialCategory === GeospatialDataCategories.UrbanAerialPhotos ||
     metadata.geospatialCategory === GeospatialDataCategories.RuralAerialPhotos ||
     metadata.geospatialCategory === GeospatialDataCategories.SatelliteImagery ||


### PR DESCRIPTION
### Motivation
aerial-photos is a category available in our argo workflows, but the standardising workflow fails to create STAC when selected.

### Modifications
Add `GeospatialDataCategories.AerialPhotos` as a valid category in function `generatePath` and appropriate test.

### Verification

Passing unit tests.
