### PR TITLE
fix(basemaps): Remove the default minzoom setting for Satellite imagery

### DIFF
--- a/src/commands/basemaps-github/make.cog.github.ts
+++ b/src/commands/basemaps-github/make.cog.github.ts
@@ -34,7 +34,7 @@ export interface CategorySetting {
 export const DefaultCategorySetting: Record<Category, CategorySetting> = {
   'Urban Aerial Photos': { minZoom: 14 },
   'Rural Aerial Photos': { minZoom: 13 },
-  'Satellite Imagery': { minZoom: 5 },
+  'Satellite Imagery': {},
   Elevation: { minZoom: 9 },
   'Scanned Aerial Imagery': { minZoom: 0, maxZoom: 32 },
   'New Aerial Photos': {},


### PR DESCRIPTION
### Motivation

Satellite imagery should not have default minzoom setting when creating configs. 

### Modifications

Removed the minzoom setting.

### Verification

<!-- TODO: Say how you tested your changes. -->
