### PR TITLE
docs: fix spelling in CLI help text for stac setup

### DIFF
--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -64,7 +64,7 @@ export const commandStacSetup = command({
       type: boolean,
       defaultValue: () => false,
       long: 'validate',
-      description: 'Validate GSD of dataset if odr_url is supplied',
+      description: 'Validate GSD of dataset if --odr-url is supplied',
       defaultValueIsSerializable: true,
     }),
 


### PR DESCRIPTION
### Motivation
CLI parameter was spelled incorrectly

### Modifications
In stac steup CLI args description, changed `odr_url` to `--odr-url` to be consistent with CLI.

### Verification
Passing tests