### PR TITLE
feat: allow 16 bit tiffs with rgb+nir

### DIFF
--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -25,6 +25,7 @@ import {
   TiffLoader,
   validate8BitsTiff,
   validatePreset,
+  validateTiffSamples,
 } from '../tileindex.validate.ts';
 import { FakeCogTiff } from './tileindex.validate.data.ts';
 
@@ -263,6 +264,8 @@ describe('is8BitsTiff', () => {
       name: 'Error',
       message: `${process.cwd()}/src/commands/tileindex-validate/__test__/data/16b.tiff is not a 8 bits TIFF`,
     });
+
+    assert.ok(await validateTiffSamples(testTiff, new Set([16])));
   });
 });
 

--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -262,10 +262,11 @@ describe('is8BitsTiff', () => {
     const testTiff = await createTiff(pathToFileURL('./src/commands/tileindex-validate/__test__/data/16b.tiff'));
     await assert.rejects(validate8BitsTiff(testTiff), {
       name: 'Error',
-      message: `${process.cwd()}/src/commands/tileindex-validate/__test__/data/16b.tiff is not a 8 bits TIFF`,
+      message: `${process.cwd()}/src/commands/tileindex-validate/__test__/data/16b.tiff has unsupported bit depth: 16, 16, 16. Expected: 8`,
     });
 
-    assert.ok(await validateTiffSamples(testTiff, new Set([16])));
+    const ret = await validateTiffSamples(testTiff, new Set([16]));
+    assert.equal(ret, 16);
   });
 });
 
@@ -274,7 +275,7 @@ describe('validatePreset', () => {
     const test16bTiff = await createTiff(pathToFileURL('./src/commands/tileindex-validate/__test__/data/16b.tiff'));
     const test8bTiff = await createTiff(pathToFileURL('./src/commands/tileindex-validate/__test__/data/8b.tiff'));
     const fatalStub = t.mock.method(logger, 'fatal');
-    await assert.rejects(validatePreset(preset, [test16bTiff, test16bTiff, test8bTiff]), {
+    await assert.rejects(validatePreset(preset, [test8bTiff, test16bTiff, test16bTiff]), {
       name: 'Error',
       message: `Tiff preset:"${preset}" validation failed`,
     });
@@ -282,7 +283,7 @@ describe('validatePreset', () => {
     assert.equal(fatalStub.mock.callCount(), 2); // Should be called per tiff failure
     const opts = fatalStub.mock.calls[0]?.arguments[0] as unknown as Record<string, string>;
     assert.equal(opts['preset'], preset);
-    assert.ok(opts['reason']?.includes('is not a 8 bits TIFF'));
+    assert.ok(opts['reason']?.includes('bit depth'));
   }
   it('should validate multiple tiffs for webp', async (t) => {
     await testValidatePresetTiffs(t, 'webp');

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -482,14 +482,29 @@ export async function validatePreset(preset: string, tiffs: Tiff[]): Promise<voi
   const bitSet = allowedBitsForPreset(preset);
   if (bitSet == null) return;
 
-  const promises = tiffs.map((f) => {
-    return validateTiffSamples(f, bitSet).catch((err) => {
+  let bitCount: number | null = null;
+
+  const promises = tiffs.map(async (t) => {
+    const value = await validateTiffSamples(t, bitSet).catch((err) => {
       logger.fatal(
-        { reason: String(err), source: protocolAwareString(f.source.url), preset },
+        { reason: String(err), source: protocolAwareString(t.source.url), preset },
         'Tiff:ValidatePreset:failed',
       );
       rejected = true;
     });
+    if (value == null) return;
+    if (bitCount == null) bitCount = value;
+    if (bitCount !== value) {
+      logger.fatal(
+        {
+          reason: `${protocolAwareString(t.source.url)} Inconsistent bit depth across bands: ${bitCount} vs ${value}}`,
+          source: protocolAwareString(t.source.url),
+          preset,
+        },
+        'Tiff:ValidatePreset:failed',
+      );
+      rejected = true;
+    }
   });
   await Promise.allSettled(promises);
 
@@ -691,7 +706,7 @@ export const BitSet8 = new Set([8]);
  * @param tiff
  */
 export async function validate8BitsTiff(tiff: Tiff): Promise<void> {
-  return validateTiffSamples(tiff, BitSet8);
+  await validateTiffSamples(tiff, BitSet8);
 }
 
 /**
@@ -700,7 +715,7 @@ export async function validate8BitsTiff(tiff: Tiff): Promise<void> {
  * @param tiff
  * @param allowedBitCount
  */
-export async function validateTiffSamples(tiff: Tiff, allowedBitCount: Set<number>): Promise<void> {
+export async function validateTiffSamples(tiff: Tiff, allowedBitCount: Set<number>): Promise<number> {
   const baseImage = tiff.images[0];
   if (baseImage === undefined) throw new Error(`Can't get base image for ${protocolAwareString(tiff.source.url)}`);
 
@@ -723,6 +738,8 @@ export async function validateTiffSamples(tiff: Tiff, allowedBitCount: Set<numbe
       );
     }
   }
+
+  return firstSample;
 }
 
 /**

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -464,6 +464,12 @@ export function determineGridSizeFromGSDPreset(gsd: number, preset: string): Gri
   throw new Error(`Unknown preset: ${preset}`);
 }
 
+function allowedBitsForPreset(preset: string): Set<number> | null {
+  if (preset === 'webp') return new Set([8]);
+  if (preset === 'rgbnir_zstd') return new Set([8, 16]);
+  return null;
+}
+
 /**
  * Validate the tiffs against a validation preset
  *
@@ -473,18 +479,19 @@ export function determineGridSizeFromGSDPreset(gsd: number, preset: string): Gri
 export async function validatePreset(preset: string, tiffs: Tiff[]): Promise<void> {
   let rejected = false;
 
-  if (preset === 'webp' || preset === 'rgbnir_zstd') {
-    const promises = tiffs.map((f) => {
-      return validate8BitsTiff(f).catch((err) => {
-        logger.fatal(
-          { reason: String(err), source: protocolAwareString(f.source.url), preset },
-          'Tiff:ValidatePreset:failed',
-        );
-        rejected = true;
-      });
+  const bitSet = allowedBitsForPreset(preset);
+  if (bitSet == null) return;
+
+  const promises = tiffs.map((f) => {
+    return validateTiffSamples(f, bitSet).catch((err) => {
+      logger.fatal(
+        { reason: String(err), source: protocolAwareString(f.source.url), preset },
+        'Tiff:ValidatePreset:failed',
+      );
+      rejected = true;
     });
-    await Promise.allSettled(promises);
-  }
+  });
+  await Promise.allSettled(promises);
 
   if (rejected) throw new Error(`Tiff preset:"${preset}" validation failed`);
 }
@@ -677,22 +684,44 @@ export function getTileName(x: number, y: number, gridSize: GridSize): string {
   return `${sheetCode}_${gridSize}_${tileId}`;
 }
 
+export const BitSet8 = new Set([8]);
 /**
  * Validate if a TIFF contains only 8 bits bands.
  *
  * @param tiff
  */
 export async function validate8BitsTiff(tiff: Tiff): Promise<void> {
+  return validateTiffSamples(tiff, BitSet8);
+}
+
+/**
+ * Ensure the tiff contains only bands with the specified bit count (e.g. 8 bits for webp preset).
+ *
+ * @param tiff
+ * @param allowedBitCount
+ */
+export async function validateTiffSamples(tiff: Tiff, allowedBitCount: Set<number>): Promise<void> {
   const baseImage = tiff.images[0];
   if (baseImage === undefined) throw new Error(`Can't get base image for ${protocolAwareString(tiff.source.url)}`);
 
   const bitsPerSample = await baseImage.fetch(TiffTag.BitsPerSample);
-  if (bitsPerSample == null) {
+  if (bitsPerSample == null || bitsPerSample.length < 1) {
     throw new Error(`Failed to extract band information from ${protocolAwareString(tiff.source.url)}`);
   }
 
-  if (!bitsPerSample.every((currentNumberBits) => currentNumberBits === 8)) {
-    throw new Error(`${protocolAwareString(tiff.source.url)} is not a 8 bits TIFF`);
+  const firstSample = bitsPerSample[0] as number;
+  if (!allowedBitCount.has(firstSample)) {
+    throw new Error(
+      `${protocolAwareString(tiff.source.url)} has unsupported bit depth: ${bitsPerSample.join(', ')}. Expected: ${[...allowedBitCount].join(', ')}`,
+    );
+  }
+
+  for (let i = 1; i < bitsPerSample.length; i++) {
+    if (bitsPerSample[i] !== firstSample) {
+      throw new Error(
+        `${protocolAwareString(tiff.source.url)} Inconsistent bit depth across bands: ${bitsPerSample.join(', ')}`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation

In some cases we should be allowing 16bit rgbinir, to test the process temporarlly allow 16bit nir to pass the validation logic

### Modifications

allow rgbnir datasets to be either 8bit or 16bit provided all bands are consistent

### Verification

<!-- TODO: Say how you tested your changes. -->
