### PR TITLE
feat: changed aerial photos to ancillary aerial photos TDE-1924

### DIFF
--- a/src/commands/generate-path/__test__/generate.path.test.ts
+++ b/src/commands/generate-path/__test__/generate.path.test.ts
@@ -27,7 +27,7 @@ describe('GeneratePathImagery', () => {
   it('Should match - generic aerial photos from slug', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-imagery',
-      geospatialCategory: 'aerial-photos',
+      geospatialCategory: 'ancillary-aerial-photos',
       region: 'auckland',
       slug: 'auckland_2023_0.3m',
       gsd: 0.3,

--- a/src/commands/generate-path/__test__/generate.path.test.ts
+++ b/src/commands/generate-path/__test__/generate.path.test.ts
@@ -24,7 +24,7 @@ describe('GeneratePathImagery', () => {
     };
     assert.equal(generatePath(metadata), 's3://nz-imagery/auckland/auckland_2023_0.3m/rgb/2193/');
   });
-  it('Should match - generic aerial photos from slug', () => {
+  it('Should match - generic ancillary aerial photos from slug', () => {
     const metadata: PathMetadata = {
       targetBucketName: 'nz-imagery',
       geospatialCategory: 'ancillary-aerial-photos',
@@ -34,6 +34,18 @@ describe('GeneratePathImagery', () => {
       epsg: 2193,
     };
     assert.equal(generatePath(metadata), 's3://nz-imagery/auckland/auckland_2023_0.3m/rgb/2193/');
+  });
+
+  it('Should match - generic ancillary near infrared aerial photos from slug', () => {
+    const metadata: PathMetadata = {
+      targetBucketName: 'nz-imagery',
+      geospatialCategory: 'ancillary-near-infrared-aerial-photos',
+      region: 'auckland',
+      slug: 'auckland_2023_0.3m',
+      gsd: 0.3,
+      epsg: 2193,
+    };
+    assert.equal(generatePath(metadata), 's3://nz-imagery/auckland/auckland_2023_0.3m/rgbnir/2193/'); 
   });
 
   it('Should match - scanned aerial photos from slug', () => {

--- a/src/commands/generate-path/path.generate.ts
+++ b/src/commands/generate-path/path.generate.ts
@@ -77,7 +77,7 @@ export const commandGeneratePath = command({
  */
 export function generatePath(metadata: PathMetadata): string {
   if (
-    metadata.geospatialCategory === GeospatialDataCategories.AerialPhotos ||
+    metadata.geospatialCategory === GeospatialDataCategories.AncillaryAerialPhotos ||
     metadata.geospatialCategory === GeospatialDataCategories.UrbanAerialPhotos ||
     metadata.geospatialCategory === GeospatialDataCategories.RuralAerialPhotos ||
     metadata.geospatialCategory === GeospatialDataCategories.SatelliteImagery ||
@@ -87,7 +87,8 @@ export function generatePath(metadata: PathMetadata): string {
   }
   if (
     metadata.geospatialCategory === GeospatialDataCategories.NearInfraredAerialPhotos ||
-    metadata.geospatialCategory === GeospatialDataCategories.NearInfraredSatelliteImagery
+    metadata.geospatialCategory === GeospatialDataCategories.NearInfraredSatelliteImagery ||
+    metadata.geospatialCategory === GeospatialDataCategories.AncillaryNearInfraredAerialPhotos
   ) {
     return `s3://${metadata.targetBucketName}/${metadata.region}/${metadata.slug}/rgbnir/${metadata.epsg}/`;
   }

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -159,6 +159,7 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
 
   switch (metadata.geospatialCategory) {
     case 'ancillary-aerial-photos':
+    case 'ancillary-near-infrared-aerial-photos':
     case 'near-infrared-aerial-photos':
     case 'near-infrared-satellite-imagery':
     case 'rural-aerial-photos':

--- a/src/commands/stac-setup/stac.setup.ts
+++ b/src/commands/stac-setup/stac.setup.ts
@@ -158,7 +158,7 @@ export function slugFromMetadata(metadata: SlugMetadata): string {
   const geographicDescription = metadata.geographicDescription || metadata.region;
 
   switch (metadata.geospatialCategory) {
-    case 'aerial-photos':
+    case 'ancillary-aerial-photos':
     case 'near-infrared-aerial-photos':
     case 'near-infrared-satellite-imagery':
     case 'rural-aerial-photos':

--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -470,36 +470,36 @@ describe('isTiff', () => {
 });
 
 describe('determineGridSizeFromGSDPreset', () => {
-  // Aerial Imagery (preset: 'webp')
-  it('returns 1000 for aerial imagery < 0.1m', () => {
+  // Ancillary Aerial Imagery (preset: 'webp')
+  it('returns 1000 for ancillary aerial imagery < 0.1m', () => {
     assert.strictEqual(determineGridSizeFromGSDPreset(0.05, 'webp'), 1000);
   });
-  it('returns 5000 for aerial imagery >= 0.1m and < 0.25m', () => {
+  it('returns 5000 for ancillary aerial imagery >= 0.1m and < 0.25m', () => {
     assert.strictEqual(determineGridSizeFromGSDPreset(0.1, 'webp'), 5000);
     assert.strictEqual(determineGridSizeFromGSDPreset(0.249, 'webp'), 5000);
   });
-  it('returns 10000 for aerial imagery >= 0.25m and < 1.0m', () => {
+  it('returns 10000 for ancillary aerial imagery >= 0.25m and < 1.0m', () => {
     assert.strictEqual(determineGridSizeFromGSDPreset(0.25, 'webp'), 10000);
     assert.strictEqual(determineGridSizeFromGSDPreset(0.999, 'webp'), 10000);
   });
-  it('returns 50000 for aerial imagery >= 1.0m', () => {
+  it('returns 50000 for ancillary aerial imagery >= 1.0m', () => {
     assert.strictEqual(determineGridSizeFromGSDPreset(1.0, 'webp'), 50000);
     assert.strictEqual(determineGridSizeFromGSDPreset(2.0, 'webp'), 50000);
   });
 
-  // Near-Infrared Aerial Imagery (preset: 'rgbnir_zstd')
-  it('returns 1000 for near-infrared aerial imagery < 0.1m', () => {
+  // Ancillary Near-Infrared Aerial Imagery (preset: 'rgbnir_zstd')
+  it('returns 1000 for ancillary near-infrared aerial imagery < 0.1m', () => {
     assert.strictEqual(determineGridSizeFromGSDPreset(0.05, 'rgbnir_zstd'), 1000);
   });
-  it('returns 5000 for near-infrared aerial imagery >= 0.1m and < 0.25m', () => {
+  it('returns 5000 for ancillary near-infrared aerial imagery >= 0.1m and < 0.25m', () => {
     assert.strictEqual(determineGridSizeFromGSDPreset(0.1, 'rgbnir_zstd'), 5000);
     assert.strictEqual(determineGridSizeFromGSDPreset(0.249, 'rgbnir_zstd'), 5000);
   });
-  it('returns 10000 for near-infrared aerial imagery >= 0.25m and < 1.0m', () => {
+  it('returns 10000 for ancillary near-infrared aerial imagery >= 0.25m and < 1.0m', () => {
     assert.strictEqual(determineGridSizeFromGSDPreset(0.25, 'rgbnir_zstd'), 10000);
     assert.strictEqual(determineGridSizeFromGSDPreset(0.999, 'rgbnir_zstd'), 10000);
   });
-  it('returns 50000 for near-infrared near-infrared aerial imagery >= 1.0m', () => {
+  it('returns 50000 for ancillary near-infrared near-infrared aerial imagery >= 1.0m', () => {
     assert.strictEqual(determineGridSizeFromGSDPreset(1.0, 'rgbnir_zstd'), 50000);
     assert.strictEqual(determineGridSizeFromGSDPreset(2.0, 'rgbnir_zstd'), 50000);
   });

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -447,7 +447,7 @@ function validateTiling(outputTiles: Map<string, TiffLocation[]>): void {
  * @param preset 'webp' for aerial imagery, 'rgbnir_zstd' for near-infrared aerial imagery, 'dem_lerc' for DEM/DSM/Hillshade
  */
 export function determineGridSizeFromGSDPreset(gsd: number, preset: string): GridSize {
-  // Aerial Imagery and Near-Infrared Aerial Imagery
+  // Ancillary Aerial Imagery and Ancillary Near-Infrared Aerial Imagery
   if (preset === 'webp' || preset === 'rgbnir_zstd') {
     if (gsd < 0.1) return 1000;
     if (gsd >= 0.1 && gsd < 0.25) return 5000;

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -10,7 +10,8 @@ export interface StacCollectionLinz {
 }
 
 export const GeospatialDataCategories = {
-  AerialPhotos: 'ancillary-aerial-photos',
+  AncillaryAerialPhotos: 'ancillary-aerial-photos',
+  AncillaryNearInfraredAerialPhotos: 'ancillary-near-infrared-aerial-photos',
   NearInfraredAerialPhotos: 'near-infrared-aerial-photos',
   NearInfraredSatelliteImagery: 'near-infrared-satellite-imagery',
   RuralAerialPhotos: 'rural-aerial-photos',

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -10,7 +10,7 @@ export interface StacCollectionLinz {
 }
 
 export const GeospatialDataCategories = {
-  AerialPhotos: 'aerial-photos',
+  AerialPhotos: 'ancillary-aerial-photos',
   NearInfraredAerialPhotos: 'near-infrared-aerial-photos',
   NearInfraredSatelliteImagery: 'near-infrared-satellite-imagery',
   RuralAerialPhotos: 'rural-aerial-photos',


### PR DESCRIPTION
### Motivation

To separately categorise opportunity imagery, project imagery and other random imagery
so that it can easily be split out from higher quality imagery.

### Modifications

Changed aerial-photos category to ancillary-aerial-photos and added ancillary-near-infrared-aerial-photos.

