### PR TITLE
fix(verify-restore): allow RestoreAlreadyInProgress status TDE-1988

### DIFF
--- a/src/commands/verify-restore/__test__/verify.restore.test.ts
+++ b/src/commands/verify-restore/__test__/verify.restore.test.ts
@@ -5,6 +5,7 @@ import type { HeadObjectCommandOutput } from '@aws-sdk/client-s3';
 import type { FileInfo } from '@chunkd/fs';
 import { fsa } from '@chunkd/fs';
 
+import { logger } from '../../../log.ts';
 import {
   decodeFormUrlEncoded,
   fetchPendingRestoredObjectPaths,
@@ -25,15 +26,21 @@ describe('fetchResultKeysFromReport', () => {
     assert.deepEqual(keys, [fsa.toUrl('s3://b/k'), fsa.toUrl('s3://b2/k2')]);
   });
 
-  it('throws if any result is not succeeded', async () => {
+  it('returns all keys and logs a warning if any result is not succeeded', async (t) => {
+    const warnStub = t.mock.method(logger, 'warn');
     const report = {
       Results: [
         { TaskExecutionStatus: 'succeeded', Bucket: 'b', Key: 'k', MD5Checksum: 'm' },
-        { TaskExecutionStatus: 'failed', Bucket: 'b', Key: 'k', MD5Checksum: 'm' },
-        { TaskExecutionStatus: 'succeeded', Bucket: 'b2', Key: 'k2', MD5Checksum: 'm2' },
+        { TaskExecutionStatus: 'failed', Bucket: 'b', Key: 'k2', MD5Checksum: 'm' },
+        { TaskExecutionStatus: 'succeeded', Bucket: 'b2', Key: 'k3', MD5Checksum: 'm2' },
       ],
     };
-    assert.throws(() => fetchResultKeysFromReport(report), { message: /not succeeded/ });
+    const keys = fetchResultKeysFromReport(report);
+    assert.deepEqual(keys, [fsa.toUrl('s3://b/k'), fsa.toUrl('s3://b/k2'), fsa.toUrl('s3://b2/k3')]);
+
+    assert.equal(warnStub.mock.callCount(), 1);
+    const opts = warnStub.mock.calls[0]?.arguments[0] as unknown as Record<string, string[]>;
+    assert.deepEqual(opts['results'], ['s3://b/k2']);
   });
 });
 
@@ -54,7 +61,7 @@ describe('fetchPendingRestoredObjectPaths', () => {
     assert.deepEqual(files, [{ Bucket: 'b', Key: 'k' }]);
   });
 
-  it('throws if any request is not successful', async () => {
+  it('throws if any request is not successful except RestoreAlreadyInProgress', async () => {
     const entries = [
       {
         Bucket: 'b',
@@ -79,12 +86,48 @@ describe('fetchPendingRestoredObjectPaths', () => {
         Key: 'k',
         VersionId: '',
         TaskStatus: '',
+        ErrorCode: 'Failed',
+        HTTPStatusCode: '',
+        ResultMessage: 'RestoreAlreadyInProgress',
+      },
+      {
+        Bucket: 'b',
+        Key: 'k',
+        VersionId: '',
+        TaskStatus: '',
         ErrorCode: '',
         HTTPStatusCode: '',
         ResultMessage: 'Successful',
       },
     ];
     assert.throws(() => fetchPendingRestoredObjectPaths(entries), { message: /not successful/ });
+  });
+
+  it('treats RestoreAlreadyInProgress as successful', () => {
+    const entries = [
+      {
+        Bucket: 'b',
+        Key: 'k',
+        VersionId: '',
+        TaskStatus: '',
+        ErrorCode: '',
+        HTTPStatusCode: '',
+        ResultMessage: 'Successful',
+      },
+      {
+        Bucket: 'b',
+        Key: 'k2',
+        VersionId: '',
+        TaskStatus: '',
+        ErrorCode: 'Failed',
+        HTTPStatusCode: '',
+        ResultMessage: 'RestoreAlreadyInProgress',
+      },
+    ];
+    assert.deepEqual(fetchPendingRestoredObjectPaths(entries), [
+      { Bucket: 'b', Key: 'k' },
+      { Bucket: 'b', Key: 'k2' },
+    ]);
   });
 
   it('treats ResultMessage with trailing \\r as successful', () => {

--- a/src/commands/verify-restore/__test__/verify.restore.test.ts
+++ b/src/commands/verify-restore/__test__/verify.restore.test.ts
@@ -103,7 +103,8 @@ describe('fetchPendingRestoredObjectPaths', () => {
     assert.throws(() => fetchPendingRestoredObjectPaths(entries), { message: /not successful: k-failed$/ });
   });
 
-  it('treats RestoreAlreadyInProgress as successful', () => {
+  it('treats RestoreAlreadyInProgress as successful and logs a warning', (t) => {
+    const warnStub = t.mock.method(logger, 'warn');
     const entries = [
       {
         Bucket: 'b',
@@ -128,6 +129,10 @@ describe('fetchPendingRestoredObjectPaths', () => {
       { Bucket: 'b', Key: 'k' },
       { Bucket: 'b', Key: 'k2' },
     ]);
+
+    assert.equal(warnStub.mock.callCount(), 1);
+    const opts = warnStub.mock.calls[0]?.arguments[0] as unknown as Record<string, string[]>;
+    assert.deepEqual(opts['keys'], ['k2']);
   });
 
   it('treats ResultMessage with trailing \\r as successful', () => {

--- a/src/commands/verify-restore/__test__/verify.restore.test.ts
+++ b/src/commands/verify-restore/__test__/verify.restore.test.ts
@@ -74,21 +74,21 @@ describe('fetchPendingRestoredObjectPaths', () => {
       },
       {
         Bucket: 'b',
-        Key: 'k',
+        Key: 'k-failed',
         VersionId: '',
-        TaskStatus: '',
-        ErrorCode: '',
-        HTTPStatusCode: '',
-        ResultMessage: 'Failed',
+        TaskStatus: 'failed',
+        ErrorCode: 'InvalidObjectState',
+        HTTPStatusCode: '403',
+        ResultMessage: 'Object is not eligible for restore',
       },
       {
         Bucket: 'b',
-        Key: 'k',
+        Key: 'k-in-progress',
         VersionId: '',
-        TaskStatus: '',
-        ErrorCode: 'Failed',
-        HTTPStatusCode: '',
-        ResultMessage: 'RestoreAlreadyInProgress',
+        TaskStatus: 'failed',
+        ErrorCode: 'RestoreAlreadyInProgress',
+        HTTPStatusCode: '409',
+        ResultMessage: 'Object restore is already in progress (Service: Amazon S3; Status Code: 409)',
       },
       {
         Bucket: 'b',
@@ -100,7 +100,7 @@ describe('fetchPendingRestoredObjectPaths', () => {
         ResultMessage: 'Successful',
       },
     ];
-    assert.throws(() => fetchPendingRestoredObjectPaths(entries), { message: /not successful/ });
+    assert.throws(() => fetchPendingRestoredObjectPaths(entries), { message: /not successful: k-failed$/ });
   });
 
   it('treats RestoreAlreadyInProgress as successful', () => {
@@ -118,10 +118,10 @@ describe('fetchPendingRestoredObjectPaths', () => {
         Bucket: 'b',
         Key: 'k2',
         VersionId: '',
-        TaskStatus: '',
-        ErrorCode: 'Failed',
-        HTTPStatusCode: '',
-        ResultMessage: 'RestoreAlreadyInProgress',
+        TaskStatus: 'failed',
+        ErrorCode: 'RestoreAlreadyInProgress',
+        HTTPStatusCode: '409',
+        ResultMessage: 'Object restore is already in progress (Service: Amazon S3; Status Code: 409)',
       },
     ];
     assert.deepEqual(fetchPendingRestoredObjectPaths(entries), [

--- a/src/commands/verify-restore/verify.restore.ts
+++ b/src/commands/verify-restore/verify.restore.ts
@@ -131,6 +131,11 @@ export function fetchResultKeysFromReport(report: ManifestReport): URL[] {
  * @returns An array of objects containing the Bucket and Key of each restored object.
  */
 export function fetchPendingRestoredObjectPaths(resultEntries: ReportResult[]): { Bucket: string; Key: string }[] {
+  const alreadyInProgressRequests = resultEntries.filter((row) => row.ErrorCode.trim() === 'RestoreAlreadyInProgress');
+  if (alreadyInProgressRequests.length) {
+    logger.warn({ keys: alreadyInProgressRequests.map((row) => row.Key) }, 'VerifyRestore:RestoreAlreadyInProgress');
+  }
+
   const notSuccessfulRequests = resultEntries.filter((row: ReportResult) => {
     return row.ResultMessage.trim() !== 'Successful' && row.ErrorCode.trim() !== 'RestoreAlreadyInProgress';
   });

--- a/src/commands/verify-restore/verify.restore.ts
+++ b/src/commands/verify-restore/verify.restore.ts
@@ -104,7 +104,8 @@ export const commandVerifyRestore = command({
 
 /**
  * Fetches the result keys from the manifest report.
- * Throws an error if any of the results did not succeed.
+ * Logs a warning if any of the results did not succeed, as the individual
+ * restore failures are caught when inspecting the result CSV files.
  *
  * @param report - The manifest report containing results.
  * @returns An array of S3 paths for the restored files.
@@ -113,8 +114,9 @@ export function fetchResultKeysFromReport(report: ManifestReport): URL[] {
   const { Results } = report;
   const notSucceeded = Results.filter((r) => r.TaskExecutionStatus?.toLowerCase() !== 'succeeded');
   if (notSucceeded.length) {
-    throw new Error(
-      `Some report results have not succeeded: ${notSucceeded.map((r) => `s3://${r.Bucket}/${r.Key}`).join(', ')}`,
+    logger.warn(
+      { results: notSucceeded.map((r) => `s3://${r.Bucket}/${r.Key}`) },
+      'VerifyRestore:ReportResultsNotSucceeded',
     );
   }
 
@@ -122,13 +124,17 @@ export function fetchResultKeysFromReport(report: ManifestReport): URL[] {
 }
 
 /** Fetches the paths of pending restored objects from the report results.
- * Throws an error if any restore requests are not successful.
+ * Throws an error if any restore requests are not successful, ignoring requests
+ * that are already in progress.
  *
  * @param resultEntries - The report results containing object paths and statuses.
  * @returns An array of objects containing the Bucket and Key of each restored object.
  */
 export function fetchPendingRestoredObjectPaths(resultEntries: ReportResult[]): { Bucket: string; Key: string }[] {
-  const notSuccessfulRequests = resultEntries.filter((row: ReportResult) => row.ResultMessage.trim() !== 'Successful');
+  const notSuccessfulRequests = resultEntries.filter((row: ReportResult) => {
+    const message = row.ResultMessage.trim();
+    return message !== 'Successful' && message !== 'RestoreAlreadyInProgress';
+  });
   if (notSuccessfulRequests.length) {
     throw new Error(
       `Some restore requests are not successful: ${notSuccessfulRequests.map((row) => row.Key).join(', ')}`,

--- a/src/commands/verify-restore/verify.restore.ts
+++ b/src/commands/verify-restore/verify.restore.ts
@@ -132,8 +132,7 @@ export function fetchResultKeysFromReport(report: ManifestReport): URL[] {
  */
 export function fetchPendingRestoredObjectPaths(resultEntries: ReportResult[]): { Bucket: string; Key: string }[] {
   const notSuccessfulRequests = resultEntries.filter((row: ReportResult) => {
-    const message = row.ResultMessage.trim();
-    return message !== 'Successful' && message !== 'RestoreAlreadyInProgress';
+    return row.ResultMessage.trim() !== 'Successful' && row.ErrorCode.trim() !== 'RestoreAlreadyInProgress';
   });
   if (notSuccessfulRequests.length) {
     throw new Error(


### PR DESCRIPTION
### Motivation

If there are unarchive workflows that have requested the same files, the second one requested will fail when running the `cron-check-restore-copy` workflow.

We need to ignore failures with a status of `RestoreAlreadyInProgress`.

### Modifications

Instead of throwing an error when the manifest contains a link to an error report CSV, log a warning and only throw an error if all paths in the error report CSV are not successful and failed with an ErrorCode that is not `RestoreAlreadyInProgress`.

### Verification

Unit tests and PR container.
