### PR TITLE
feat: Chatham Islands EPSG:3793 and mapsheets TDE-1990

### DIFF
--- a/src/commands/tileindex-validate/README.md
+++ b/src/commands/tileindex-validate/README.md
@@ -14,14 +14,15 @@ tileindex-validate <options> [...location]
 
 ### Options
 
-| Usage                  | Description                                                                                                                                                   | Options       |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| --config <str>         | Location of role configuration file                                                                                                                           | optional      |
-| --include <str>        | Include files eg ".\*.tiff?$"                                                                                                                                 | optional      |
-| --scale <value>        | Tile grid scale to align output tile to. If set to "auto", the system will determine the appropriate scale based on the imagery type (`--preset`) and its GSD | optional      |
-| --source-epsg <number> | Force epsg code for input tiffs                                                                                                                               | optional      |
-| --preset <str>         | Validate the input tiffs with a configuration preset                                                                                                          | default: none |
-| --concurrency <number> | Number of TIFF files to read concurrently                                                                                                                     | optional      |
+| Usage                  | Description                                                                                                                                                                                                 | Options       |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| --config <str>         | Location of role configuration file                                                                                                                                                                         | optional      |
+| --include <str>        | Include files eg ".\*.tiff?$"                                                                                                                                                                               | optional      |
+| --scale <value>        | Tile grid scale to align output tile to. If set to "auto", the system will determine the appropriate scale based on the imagery type (`--preset`) and its GSD                                               | optional      |
+| --source-epsg <number> | Force epsg code for input tiffs                                                                                                                                                                             | optional      |
+| --target-epsg <value>  | Target CRS to align output tiles to and calculate map sheet names in. Defaults to the (source) EPSG of the input tiffs; set to 2193 (NZTM2000) or 3793 (Chatham Islands) to reproject into a specific grid. | optional      |
+| --preset <str>         | Validate the input tiffs with a configuration preset                                                                                                                                                        | default: none |
+| --concurrency <number> | Number of TIFF files to read concurrently                                                                                                                                                                   | optional      |
 
 ### Flags
 

--- a/src/commands/tileindex-validate/README.md
+++ b/src/commands/tileindex-validate/README.md
@@ -14,15 +14,15 @@ tileindex-validate <options> [...location]
 
 ### Options
 
-| Usage                  | Description                                                                                                                                                                                                 | Options       |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| --config <str>         | Location of role configuration file                                                                                                                                                                         | optional      |
-| --include <str>        | Include files eg ".\*.tiff?$"                                                                                                                                                                               | optional      |
-| --scale <value>        | Tile grid scale to align output tile to. If set to "auto", the system will determine the appropriate scale based on the imagery type (`--preset`) and its GSD                                               | optional      |
-| --source-epsg <number> | Force epsg code for input tiffs                                                                                                                                                                             | optional      |
-| --target-epsg <value>  | Target CRS to align output tiles to and calculate map sheet names in. Defaults to the (source) EPSG of the input tiffs; set to 2193 (NZTM2000) or 3793 (Chatham Islands) to reproject into a specific grid. | optional      |
-| --preset <str>         | Validate the input tiffs with a configuration preset                                                                                                                                                        | default: none |
-| --concurrency <number> | Number of TIFF files to read concurrently                                                                                                                                                                   | optional      |
+| Usage                  | Description                                                                                                                                                                                          | Options       |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| --config <str>         | Location of role configuration file                                                                                                                                                                  | optional      |
+| --include <str>        | Include files eg ".\*.tiff?$"                                                                                                                                                                        | optional      |
+| --scale <value>        | Tile grid scale to align output tile to. If set to "auto", the system will determine the appropriate scale based on the imagery type (`--preset`) and its GSD                                        | optional      |
+| --source-epsg <number> | Force epsg code for input tiffs                                                                                                                                                                      | optional      |
+| --target-epsg <value>  | Target CRS to align output tiles to and calculate map sheet names in. Defaults to the (source) EPSG of the input tiffs; set to 2193 (NZTM2000) or 3793 (CITM2000) to reproject into a specific grid. | optional      |
+| --preset <str>         | Validate the input tiffs with a configuration preset                                                                                                                                                 | default: none |
+| --concurrency <number> | Number of TIFF files to read concurrently                                                                                                                                                            | optional      |
 
 ### Flags
 

--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -10,7 +10,7 @@ import { logger } from '../../../log.ts';
 import { MapSheetData } from '../../../utils/__test__/mapsheet.data.ts';
 import type { FileListEntryClass } from '../../../utils/filelist.ts';
 import type { GridSize } from '../../../utils/mapsheet.ts';
-import { MapSheet } from '../../../utils/mapsheet.ts';
+import { ChathamMapSheet, MapSheet } from '../../../utils/mapsheet.ts';
 import { createTiff, Url } from '../../common.ts';
 import {
   commandTileIndexValidate,
@@ -120,13 +120,24 @@ describe('tiffLocation', () => {
     );
   });
 
-  it('should find tiles from 3857', async () => {
+  it('should find tiles from 3857 when explicitly reprojecting to 2193', async () => {
     const TiffAy29 = FakeCogTiff.fromTileName('AY29_1000_0101');
     TiffAy29.images[0].epsg = 3857;
     TiffAy29.images[0].origin[0] = 19128043.69337794;
     TiffAy29.images[0].origin[1] = -4032710.6009459053;
-    const location = await extractTiffLocations([TiffAy29], 1000);
+    const location = await extractTiffLocations([TiffAy29], 1000, undefined, 2193);
     assert.deepEqual(location[0]?.tileNames, ['AS21_1000_0101']);
+  });
+
+  it('should fail for a source EPSG with no known map sheet grid when no target-epsg is given', async () => {
+    // 3857 has no map sheet grid of its own, and with no explicit target-epsg there is nothing to
+    // reproject into - this must fail loudly rather than silently mis-tiling (as previously happened
+    // for Chatham Islands imagery, see the "Chatham Islands" test below).
+    const TiffAy29 = FakeCogTiff.fromTileName('AY29_1000_0101');
+    TiffAy29.images[0].epsg = 3857;
+    TiffAy29.images[0].origin[0] = 19128043.69337794;
+    TiffAy29.images[0].origin[1] = -4032710.6009459053;
+    await assert.rejects(extractTiffLocations([TiffAy29], 1000));
   });
 
   it('should fail if one location is not extracted', async () => {
@@ -138,6 +149,40 @@ describe('tiffLocation', () => {
     TiffAy29.images[0].origin[1] = 6018000;
     TiffAy29.images[0].epsg = 0; // make the projection failing
     await assert.rejects(extractTiffLocations([TiffAs21, TiffAy29], 1000));
+  });
+
+  it('should tile Chatham Islands (EPSG:3793) imagery against the Chatham grid when explicitly requested', async () => {
+    // Regression test: this exact file caused a real production incident where tileindex-validate
+    // reprojected it into NZTM2000 and mis-tiled it against the mainland grid (as "BZ59"/"CB61"
+    // etc.) instead of recognising it as Chatham Islands (CI06) imagery.
+    const chathamTileIndex = ChathamMapSheet.getMapTileIndex('CI06_5000_0507');
+    if (chathamTileIndex == null) throw new Error('Failed to compute test fixture tile index');
+
+    const TiffCI06 = new FakeCogTiff('s3://path/CI06_5000_0507.tiff', {
+      origin: [chathamTileIndex.origin.x, chathamTileIndex.origin.y],
+      size: { width: chathamTileIndex.width, height: chathamTileIndex.height },
+      epsg: 3793,
+    });
+
+    const location = await extractTiffLocations([TiffCI06], 5000, undefined, 3793);
+    assert.deepEqual(location[0]?.tileNames, ['CI06_5000_0507']);
+  });
+
+  it('should tile Chatham Islands (EPSG:3793) imagery against the Chatham grid by default, with no target-epsg given', async () => {
+    // Same fixture as above, but relying entirely on the default (no --target-epsg / 4th arg at
+    // all): imagery already tagged EPSG:3793 should tile itself against the Chatham grid without
+    // any caller having to know to ask for it.
+    const chathamTileIndex = ChathamMapSheet.getMapTileIndex('CI06_5000_0507');
+    if (chathamTileIndex == null) throw new Error('Failed to compute test fixture tile index');
+
+    const TiffCI06 = new FakeCogTiff('s3://path/CI06_5000_0507.tiff', {
+      origin: [chathamTileIndex.origin.x, chathamTileIndex.origin.y],
+      size: { width: chathamTileIndex.width, height: chathamTileIndex.height },
+      epsg: 3793,
+    });
+
+    const location = await extractTiffLocations([TiffCI06], 5000);
+    assert.deepEqual(location[0]?.tileNames, ['CI06_5000_0507']);
   });
 });
 
@@ -156,6 +201,7 @@ describe('validate', () => {
     include: undefined,
     preset: 'none',
     sourceEpsg: undefined,
+    targetEpsg: 2193,
     includeDerived: false,
     scale: 1000 as GridSize,
     forceOutput: true,
@@ -234,6 +280,33 @@ describe('validate', () => {
       {
         output: 'AS21_1000_0101',
         input: ['s3://path/AS21_1000_0101.tiff', 's3://path/AS21_1000_0101.tiff'],
+        includeDerived: false,
+      },
+    ]);
+  });
+
+  it('should tile Chatham Islands imagery end to end with no --target-epsg given', async (t) => {
+    const chathamTileIndex = ChathamMapSheet.getMapTileIndex('CI06_5000_0507');
+    if (chathamTileIndex == null) throw new Error('Failed to compute test fixture tile index');
+
+    const TiffCI06 = new FakeCogTiff('s3://path/CI06_5000_0507.tiff', {
+      origin: [chathamTileIndex.origin.x, chathamTileIndex.origin.y],
+      size: { width: chathamTileIndex.width, height: chathamTileIndex.height },
+      epsg: 3793,
+    });
+    t.mock.method(TiffLoader, 'load', () => Promise.resolve([TiffCI06]));
+
+    await commandTileIndexValidate.handler({
+      ...baseArguments,
+      targetEpsg: undefined,
+      scale: 5000 as GridSize,
+    });
+
+    const outputFileList = await fsa.readJson(fsa.toUrl('file:///tmp/tile-index-validate/file-list.json'));
+    assert.deepEqual(outputFileList, [
+      {
+        output: 'CI06_5000_0507',
+        input: ['s3://path/CI06_5000_0507.tiff'],
         includeDerived: false,
       },
     ]);
@@ -353,6 +426,7 @@ describe('GSD handling', () => {
     validate: false,
     preset: 'none',
     sourceEpsg: undefined,
+    targetEpsg: 2193,
     includeDerived: false,
     location: [[fsa.toUrl('s3://test')]],
     scale: 1000 as GridSize,

--- a/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
+++ b/src/commands/tileindex-validate/__test__/tileindex.validate.test.ts
@@ -152,9 +152,6 @@ describe('tiffLocation', () => {
   });
 
   it('should tile Chatham Islands (EPSG:3793) imagery against the Chatham grid when explicitly requested', async () => {
-    // Regression test: this exact file caused a real production incident where tileindex-validate
-    // reprojected it into NZTM2000 and mis-tiled it against the mainland grid (as "BZ59"/"CB61"
-    // etc.) instead of recognising it as Chatham Islands (CI06) imagery.
     const chathamTileIndex = ChathamMapSheet.getMapTileIndex('CI06_5000_0507');
     if (chathamTileIndex == null) throw new Error('Failed to compute test fixture tile index');
 
@@ -169,9 +166,6 @@ describe('tiffLocation', () => {
   });
 
   it('should tile Chatham Islands (EPSG:3793) imagery against the Chatham grid by default, with no target-epsg given', async () => {
-    // Same fixture as above, but relying entirely on the default (no --target-epsg / 4th arg at
-    // all): imagery already tagged EPSG:3793 should tile itself against the Chatham grid without
-    // any caller having to know to ask for it.
     const chathamTileIndex = ChathamMapSheet.getMapTileIndex('CI06_5000_0507');
     if (chathamTileIndex == null) throw new Error('Failed to compute test fixture tile index');
 

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -1,4 +1,4 @@
-import { Bounds, Projection } from '@basemaps/geo';
+import { Bounds, EpsgCode, Projection } from '@basemaps/geo';
 import { fsa } from '@chunkd/fs';
 import type { Size } from '@cogeotiff/core';
 import { Tiff, TiffTag } from '@cogeotiff/core';
@@ -15,8 +15,8 @@ import { asyncFilter } from '../../utils/chunk.ts';
 import { ConcurrentQueue } from '../../utils/concurrent.queue.ts';
 import { createFileList, protocolAwareString } from '../../utils/filelist.ts';
 import { findBoundingBox, findResolution } from '../../utils/geotiff.ts';
-import type { GridSize } from '../../utils/mapsheet.ts';
-import { GridSizes, MapSheet, MapSheetTileGridSize } from '../../utils/mapsheet.ts';
+import type { GridSize, MapSheetLike } from '../../utils/mapsheet.ts';
+import { getMapSheet, GridSizes, MapSheet, MapSheetRegistry } from '../../utils/mapsheet.ts';
 import type { CommandArguments } from '../../utils/type.util.ts';
 import { config, forceOutput, registerCli, UrlFolderList, verbose } from '../common.ts';
 import { CommandListArgs } from '../list/list.ts';
@@ -70,6 +70,22 @@ export const GridSizeFromString: Type<string, GridSize | 'auto'> = {
   },
 };
 
+export const TargetEpsgFromString: Type<string, number> = {
+  /**
+   * Convert an input string to one of the supported target EPSG codes.
+   *
+   * @param value The input string.
+   * @returns The corresponding EPSG code.
+   */
+  async from(value) {
+    const epsg = Number(value);
+    if (MapSheetRegistry[epsg] == null) {
+      throw new Error(`Invalid target-epsg "${value}"; valid values: "${Object.keys(MapSheetRegistry).join('", "')}"`);
+    }
+    return epsg;
+  },
+};
+
 export const commandTileIndexValidate = command({
   name: 'tileindex-validate',
   description:
@@ -87,6 +103,14 @@ export const commandTileIndexValidate = command({
       defaultValue: (): 'auto' => 'auto',
     }),
     sourceEpsg: option({ type: optional(number), long: 'source-epsg', description: 'Force epsg code for input tiffs' }),
+    targetEpsg: option({
+      type: optional(TargetEpsgFromString),
+      long: 'target-epsg',
+      description:
+        'Target CRS to align output tiles to and calculate map sheet names in. ' +
+        `Defaults to the (source) EPSG of the input tiffs; set to ${EpsgCode.Nztm2000} (NZTM2000) or ` +
+        `${EpsgCode.Citm2000} (Chatham Islands) to reproject into a specific grid.`,
+    }),
     forceOutput,
     preset: option({
       type: string,
@@ -195,7 +219,11 @@ export const commandTileIndexValidate = command({
       logger.info({ gsd: roundedGsd, preset: args.preset, gridSize }, 'TileIndex:AutoSelectedGridSize');
     }
 
-    const tiffLocations = await extractTiffLocations(tiffs, gridSize, args.sourceEpsg);
+    // Default to the (source) EPSG of the input tiffs so imagery tiles against its own native
+    // map sheet grid (eg Chatham Islands EPSG:3793) unless the caller explicitly asks to reproject.
+    const targetEpsg = args.targetEpsg ?? args.sourceEpsg ?? [...tiffsMetadata.projections][0] ?? EpsgCode.Nztm2000;
+
+    const tiffLocations = await extractTiffLocations(tiffs, gridSize, args.sourceEpsg, targetEpsg);
     const outputTiles = groupByTileName(tiffLocations);
     logger.info(
       {
@@ -210,7 +238,7 @@ export const commandTileIndexValidate = command({
       await generateOutputFiles(
         tiffLocations,
         outputTiles,
-        args.sourceEpsg,
+        targetEpsg,
         args.includeDerived,
         String([...tiffsMetadata.roundedGsds][0]),
       );
@@ -366,26 +394,26 @@ async function getTiffsMetadata(tiffs: Tiff[], locations: URL[]): Promise<TiffsM
  *
  * @param tiffLocations The list of source TIFF locations.
  * @param outputTiles The map of output tiles to their source TIFFs.
- * @param sourceEpsg The EPSG code of the source TIFFs.
+ * @param targetEpsg The EPSG code the tiles were aligned to (see `getMapTileIndex`/`extractTiffLocations`).
  * @param includeDerived Whether to include derived TIFFs in the output.
  * @param gsd The ground sample distance to use for the output.
  */
 async function generateOutputFiles(
   tiffLocations: TiffLocation[],
   outputTiles: Map<string, TiffLocation[]>,
-  sourceEpsg: number | undefined,
+  targetEpsg: number,
   includeDerived: boolean,
   gsd: string,
 ): Promise<void> {
+  const mapSheet = getMapSheet(targetEpsg);
+  const targetProjection = Projection.get(targetEpsg);
+
   const inputGeoJson = {
     type: 'FeatureCollection',
+    // `loc.bbox` has already been reprojected into `targetEpsg` by `extractTiffLocations`, so it
+    // must be read back out with the same projection, not the tiff's original source EPSG.
     features: tiffLocations.map((loc) => {
-      const epsg = sourceEpsg ?? loc.epsg;
-      if (epsg == null) {
-        logger.error({ source: protocolAwareString(loc.source) }, 'TileIndex:Epsg:missing');
-        return;
-      }
-      return Projection.get(epsg).boundsToGeoJsonFeature(Bounds.fromBbox(loc.bbox), {
+      return targetProjection.boundsToGeoJsonFeature(Bounds.fromBbox(loc.bbox), {
         source: loc.source,
         tileName: loc.tileNames.join(', '),
       });
@@ -395,9 +423,9 @@ async function generateOutputFiles(
   const outputGeojson = {
     type: 'FeatureCollection',
     features: [...outputTiles.keys()].map((key) => {
-      const mapTileIndex = MapSheet.getMapTileIndex(key);
+      const mapTileIndex = mapSheet.getMapTileIndex(key);
       if (mapTileIndex == null) throw new Error('Failed to extract tile information from: ' + key);
-      return Projection.get(2193).boundsToGeoJsonFeature(Bounds.fromBbox(mapTileIndex.bbox), {
+      return targetProjection.boundsToGeoJsonFeature(Bounds.fromBbox(mapTileIndex.bbox), {
         source: outputTiles.get(key)?.map((l) => l.source),
         tileName: key,
       });
@@ -559,12 +587,14 @@ export function reprojectIfNeeded(bbox: BBox, sourceProjection: Projection, targ
  * @param tiffs
  * @param gridSize
  * @param forceSourceEpsg
+ * @param targetEpsg CRS to align tiles to and calculate map sheet names in, see {@link getMapSheet}. Defaults to each tiff's own (source) EPSG, ie no reprojection.
  * @returns {TiffLocation[]}
  */
 export async function extractTiffLocations(
   tiffs: Tiff[],
   gridSize: GridSize,
   forceSourceEpsg?: number,
+  targetEpsg?: number,
 ): Promise<TiffLocation[]> {
   const result = await Promise.all(
     tiffs.map(async (tiff): Promise<TiffLocation | null> => {
@@ -580,7 +610,11 @@ export async function extractTiffLocations(
           return null;
         }
 
-        const targetProjection = Projection.get(2193);
+        // Default to the source EPSG so imagery tiles against its own native map sheet grid
+        // unless the caller explicitly asks to reproject into a different one.
+        const resolvedTargetEpsg = targetEpsg ?? sourceEpsg;
+        const mapSheet = getMapSheet(resolvedTargetEpsg);
+        const targetProjection = Projection.get(resolvedTargetEpsg);
         const sourceProjection = Projection.get(sourceEpsg);
 
         const targetBbox = reprojectIfNeeded(sourceBbox, sourceProjection, targetProjection);
@@ -593,7 +627,7 @@ export async function extractTiffLocations(
           return null;
         }
 
-        const covering = getCovering(targetBbox, gridSize);
+        const covering = getCovering(targetBbox, gridSize, mapSheet);
 
         return {
           bbox: targetBbox,
@@ -647,11 +681,12 @@ export function isTiff(url: URL): boolean {
  * @param x The x coordinate of the tile.
  * @param y The y coordinate of the tile.
  * @param gridSize The grid size of the tile.
+ * @param mapSheet The map sheet grid `x`/`y` are expressed in, see {@link getMapSheet}. Defaults to the mainland NZTM50 grid.
  * @returns The tile name.
  */
-export function getTileName(x: number, y: number, gridSize: GridSize): string {
-  const sheetCode = MapSheet.sheetCode(x, y);
-  if (!MapSheet.isKnown(sheetCode)) {
+export function getTileName(x: number, y: number, gridSize: GridSize, mapSheet: MapSheetLike = MapSheet): string {
+  const sheetCode = mapSheet.sheetCode(x, y);
+  if (!mapSheet.isKnown(sheetCode)) {
     logger.info(
       { sheetCode, x, y, gridSize },
       `Map sheet (${sheetCode}) at coordinates (${x}, ${y}) is outside the known range.`,
@@ -659,18 +694,18 @@ export function getTileName(x: number, y: number, gridSize: GridSize): string {
   }
 
   // Shorter tile names for 1:50k
-  if (gridSize === MapSheetTileGridSize) return sheetCode;
+  if (gridSize === mapSheet.gridSizeMax) return sheetCode;
 
-  const tilesPerMapSheet = Math.floor(MapSheet.gridSizeMax / gridSize);
-  const tileWidth = Math.floor(MapSheet.width / tilesPerMapSheet);
-  const tileHeight = Math.floor(MapSheet.height / tilesPerMapSheet);
+  const tilesPerMapSheet = Math.floor(mapSheet.gridSizeMax / gridSize);
+  const tileWidth = Math.floor(mapSheet.width / tilesPerMapSheet);
+  const tileHeight = Math.floor(mapSheet.height / tilesPerMapSheet);
 
   const nbDigits = gridSize === 500 ? 3 : 2;
 
-  const offsetX = Math.floor((x - MapSheet.origin.x) / MapSheet.width);
-  const offsetY = Math.floor((MapSheet.origin.y - y) / MapSheet.height);
-  const maxY = MapSheet.origin.y - offsetY * MapSheet.height;
-  const minX = MapSheet.origin.x + offsetX * MapSheet.width;
+  const offsetX = Math.floor((x - mapSheet.origin.x) / mapSheet.width);
+  const offsetY = Math.floor((mapSheet.origin.y - y) / mapSheet.height);
+  const maxY = mapSheet.origin.y - offsetY * mapSheet.height;
+  const minX = mapSheet.origin.x + offsetX * mapSheet.width;
   const tileX = Math.round(Math.floor((x - minX) / tileWidth + 1));
   const tileY = Math.round(Math.floor((maxY - y) / tileHeight + 1));
   const tileId = `${`${tileY}`.padStart(nbDigits, '0')}${`${tileX}`.padStart(nbDigits, '0')}`;
@@ -699,11 +734,12 @@ export async function validate8BitsTiff(tiff: Tiff): Promise<void> {
 /**
  * Get the list of map sheets / tiles that intersect with the given bounding box.
  *
- * @param bbox Bounding box of the area of interest (in EPSG:2193) to get the map sheets for (e.g. TIFF area).
+ * @param bbox Bounding box of the area of interest (in `mapSheet`'s CRS) to get the map sheets for (e.g. TIFF area).
  * @param gridSize Grid size of the map sheets / tiles to get.
+ * @param mapSheet The map sheet grid to tile against, see {@link getMapSheet}.
  * @param minIntersectionMeters Minimum intersection area in meters (width or height) to include the map sheet.
  */
-function getCovering(bbox: BBox, gridSize: GridSize, minIntersectionMeters = 0.15): string[] {
+function getCovering(bbox: BBox, gridSize: GridSize, mapSheet: MapSheetLike, minIntersectionMeters = 0.15): string[] {
   const SurroundingTiles = [
     { x: 1, y: 0 },
     { x: 0, y: -1 },
@@ -714,16 +750,16 @@ function getCovering(bbox: BBox, gridSize: GridSize, minIntersectionMeters = 0.1
   const targetBounds = Bounds.fromBbox(bbox);
 
   const output: string[] = [];
-  const tilesPerMapSheetSide = Math.floor(MapSheet.gridSizeMax / gridSize);
+  const tilesPerMapSheetSide = Math.floor(mapSheet.gridSizeMax / gridSize);
 
-  const tileWidth = Math.floor(MapSheet.width / tilesPerMapSheetSide);
-  const tileHeight = Math.floor(MapSheet.height / tilesPerMapSheetSide);
+  const tileWidth = Math.floor(mapSheet.width / tilesPerMapSheetSide);
+  const tileHeight = Math.floor(mapSheet.height / tilesPerMapSheetSide);
 
   const seen = new Set();
   const todo: Bounds[] = [];
 
-  const sheetName = getTileName(bbox[0], bbox[3], gridSize);
-  const sheetInfo = MapSheet.getMapTileIndex(sheetName);
+  const sheetName = getTileName(bbox[0], bbox[3], gridSize, mapSheet);
+  const sheetInfo = mapSheet.getMapTileIndex(sheetName);
   if (sheetInfo == null) throw new Error('Unable to extract sheet information for point: ' + bbox[0]);
 
   todo.push(Bounds.fromBbox(sheetInfo.bbox));
@@ -744,7 +780,7 @@ function getCovering(bbox: BBox, gridSize: GridSize, minIntersectionMeters = 0.1
     for (const pt of SurroundingTiles) todo.push(nextBounds.add({ x: pt.x * tileWidth, y: pt.y * tileHeight })); // intersection not null, so add all neighbours
     // Add to output only if the intersection is above the minimum coverage
     if (intersection.width < minIntersectionMeters || intersection.height < minIntersectionMeters) continue;
-    output.push(getTileName(nextX, nextY, gridSize));
+    output.push(getTileName(nextX, nextY, gridSize, mapSheet));
   }
 
   return output.sort();

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -80,7 +80,7 @@ export const TargetEpsgFromString: Type<string, number> = {
   async from(value) {
     const epsg = Number(value);
     if (MapSheetRegistry[epsg] == null) {
-      throw new Error(`Invalid target-epsg "${value}"; valid values: "${Object.keys(MapSheetRegistry).join('", "')}"`);
+      throw new Error(`Invalid target-epsg "${value}". valid values: "${Object.keys(MapSheetRegistry).join('", "')}"`);
     }
     return epsg;
   },

--- a/src/commands/tileindex-validate/tileindex.validate.ts
+++ b/src/commands/tileindex-validate/tileindex.validate.ts
@@ -108,8 +108,10 @@ export const commandTileIndexValidate = command({
       long: 'target-epsg',
       description:
         'Target CRS to align output tiles to and calculate map sheet names in. ' +
-        `Defaults to the (source) EPSG of the input tiffs; set to ${EpsgCode.Nztm2000} (NZTM2000) or ` +
-        `${EpsgCode.Citm2000} (Chatham Islands) to reproject into a specific grid.`,
+        'Defaults to the (source) EPSG of the input tiffs; set to ' +
+        `${Object.entries(MapSheetRegistry)
+          .map(([epsg, mapSheet]) => `${epsg} (${mapSheet.name})`)
+          .join(' or ')} to reproject into a specific grid.`,
     }),
     forceOutput,
     preset: option({

--- a/src/utils/__test__/mapsheet.test.ts
+++ b/src/utils/__test__/mapsheet.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
 import type { MapTileIndex } from '../mapsheet.ts';
-import { MapSheet, SheetRanges } from '../mapsheet.ts';
+import { ChathamMapSheet, ChathamMapSheetData, getMapSheet, MapSheet, SheetRanges } from '../mapsheet.ts';
 import { MapSheetData } from './mapsheet.data.ts';
 
 describe('MapSheets', () => {
@@ -104,4 +104,75 @@ describe('MapSheets', () => {
       assert.equal(String(mapTileIndex.bbox), String(test.bbox));
     });
   }
+});
+
+describe('ChathamMapSheet', () => {
+  // Values sourced from nz-chatham-island-linz-map-sheets-topo-150k.shp (EPSG:3793)
+  it('should extract MapTileIndex from 1:50k tile filename', () => {
+    assert.deepEqual(ChathamMapSheet.getMapTileIndex('CI06.tiff'), {
+      mapSheet: 'CI06',
+      gridSize: 50_000,
+      x: 3_506_000,
+      y: 5_104_000,
+      name: 'CI06',
+      origin: { x: 3_506_000, y: 5_104_000 },
+      width: 24_000,
+      height: 36_000,
+      bbox: [3_506_000, 5_068_000, 3_530_000, 5_104_000],
+    });
+  });
+
+  it('should extract MapTileIndex from a sub-tiled filename', () => {
+    // Regression test for a real production incident: this file genuinely exists at
+    // s3://nz-imagery/chatham-islands/chatham-islands_sn8066_1982-1983_0.375m/rgb/3793/CI06_5000_0507.tiff
+    // but tileindex-validate mis-tiled it against the mainland NZTM50 grid instead.
+    assert.deepEqual(ChathamMapSheet.getMapTileIndex('CI06_5000_0507'), {
+      mapSheet: 'CI06',
+      gridSize: 5000,
+      x: 7,
+      y: 5,
+      name: 'CI06_5000_0507',
+      origin: { x: 3_520_400, y: 5_089_600 },
+      width: 2400,
+      height: 3600,
+      bbox: [3_520_400, 5_086_000, 3_522_800, 5_089_600],
+    });
+  });
+
+  it('should calculate offsets for all six known sheets', () => {
+    for (const ms of ChathamMapSheetData) {
+      assert.deepEqual(ChathamMapSheet.offset(ms.code), ms.origin);
+      assert.equal(ChathamMapSheet.isKnown(ms.code), true);
+    }
+  });
+
+  it('should round trip all six known sheets', () => {
+    for (const ms of ChathamMapSheetData) {
+      assert.equal(ChathamMapSheet.sheetCode(ms.origin.x, ms.origin.y), ms.code);
+    }
+  });
+
+  it('should not know invalid or out-of-range sheets', () => {
+    assert.equal(ChathamMapSheet.isKnown('CI99'), false);
+    assert.equal(ChathamMapSheet.isKnown('CI00'), false); // grid cell exists but has no real sheet
+    assert.equal(ChathamMapSheet.isKnown('AS21'), false); // a real mainland sheet code
+  });
+
+  it('should not be confused with the mainland grid at the same raw x/y', () => {
+    // The mainland MapSheet formula still "works" (produces *a* answer) for Chatham Islands
+    // coordinates reprojected into NZTM2000 - it must never be mistaken for a Chatham sheet code.
+    const mainlandSheetCode = MapSheet.sheetCode(3_506_000, 5_104_000);
+    assert.notEqual(mainlandSheetCode.slice(0, 2), 'CI');
+  });
+});
+
+describe('getMapSheet', () => {
+  it('should resolve the mainland and Chatham Islands grids by EPSG code', () => {
+    assert.equal(getMapSheet(2193), MapSheet);
+    assert.equal(getMapSheet(3793), ChathamMapSheet);
+  });
+
+  it('should throw for an unsupported target EPSG', () => {
+    assert.throws(() => getMapSheet(4326), /Unsupported target EPSG:4326/);
+  });
 });

--- a/src/utils/__test__/mapsheet.test.ts
+++ b/src/utils/__test__/mapsheet.test.ts
@@ -158,6 +158,12 @@ describe('ChathamMapSheet', () => {
     assert.equal(ChathamMapSheet.isKnown('AS21'), false); // a real mainland sheet code
   });
 
+  it('should throw for the offset of an invalid or out-of-range sheet', () => {
+    assert.throws(() => ChathamMapSheet.offset('CI99'), /Unknown Chatham Islands map sheet "CI99"/);
+    assert.throws(() => ChathamMapSheet.offset('CI00'), /Unknown Chatham Islands map sheet "CI00"/);
+    assert.throws(() => ChathamMapSheet.offset('AS21'), /Unknown Chatham Islands map sheet "AS21"/);
+  });
+
   it('should not be confused with the mainland grid at the same raw x/y', () => {
     // The mainland MapSheet formula still "works" (produces *a* answer) for Chatham Islands
     // coordinates reprojected into NZTM2000 - it must never be mistaken for a Chatham sheet code.

--- a/src/utils/__test__/mapsheet.test.ts
+++ b/src/utils/__test__/mapsheet.test.ts
@@ -164,6 +164,21 @@ describe('ChathamMapSheet', () => {
     assert.throws(() => ChathamMapSheet.offset('AS21'), /Unknown Chatham Islands map sheet "AS21"/);
   });
 
+  it('should never synthesize a fake code that collides with one of the six real sheets', () => {
+    // Real codes are always "CI0X" (X 1-6); a cell far outside the archipelago's row/col range
+    // must not synthesize one of those, or it would be silently treated as a real, known sheet.
+    const knownRowCols = new Set(ChathamMapSheetData.map((s) => `${s.row},${s.col}`));
+    for (let row = -20; row <= 20; row++) {
+      for (let col = -20; col <= 20; col++) {
+        if (knownRowCols.has(`${row},${col}`)) continue;
+        const x = ChathamMapSheet.origin.x + col * ChathamMapSheet.width;
+        const y = ChathamMapSheet.origin.y - row * ChathamMapSheet.height;
+        const code = ChathamMapSheet.sheetCode(x, y);
+        assert.equal(ChathamMapSheet.isKnown(code), false, `${code} from row=${row},col=${col} must not be "known"`);
+      }
+    }
+  });
+
   it('should not be confused with the mainland grid at the same raw x/y', () => {
     // The mainland MapSheet formula still "works" (produces *a* answer) for Chatham Islands
     // coordinates reprojected into NZTM2000 - it must never be mistaken for a Chatham sheet code.

--- a/src/utils/__test__/mapsheet.test.ts
+++ b/src/utils/__test__/mapsheet.test.ts
@@ -123,9 +123,8 @@ describe('ChathamMapSheet', () => {
   });
 
   it('should extract MapTileIndex from a sub-tiled filename', () => {
-    // Regression test for a real production incident: this file genuinely exists at
-    // s3://nz-imagery/chatham-islands/chatham-islands_sn8066_1982-1983_0.375m/rgb/3793/CI06_5000_0507.tiff
-    // but tileindex-validate mis-tiled it against the mainland NZTM50 grid instead.
+    // Regression test for an issue where tileindex-validate mis-tiled
+    // a Chatham Islands tile against the mainland NZTM50 grid instead.
     assert.deepEqual(ChathamMapSheet.getMapTileIndex('CI06_5000_0507'), {
       mapSheet: 'CI06',
       gridSize: 5000,
@@ -154,7 +153,7 @@ describe('ChathamMapSheet', () => {
 
   it('should not know invalid or out-of-range sheets', () => {
     assert.equal(ChathamMapSheet.isKnown('CI99'), false);
-    assert.equal(ChathamMapSheet.isKnown('CI00'), false); // grid cell exists but has no real sheet
+    assert.equal(ChathamMapSheet.isKnown('CI00'), false); // no associated sheet
     assert.equal(ChathamMapSheet.isKnown('AS21'), false); // a real mainland sheet code
   });
 
@@ -180,7 +179,7 @@ describe('ChathamMapSheet', () => {
   });
 
   it('should not be confused with the mainland grid at the same raw x/y', () => {
-    // The mainland MapSheet formula still "works" (produces *a* answer) for Chatham Islands
+    // The mainland MapSheet formula still "works" (produces an answer) for Chatham Islands
     // coordinates reprojected into NZTM2000 - it must never be mistaken for a Chatham sheet code.
     const mainlandSheetCode = MapSheet.sheetCode(3_506_000, 5_104_000);
     assert.notEqual(mainlandSheetCode.slice(0, 2), 'CI');

--- a/src/utils/mapsheet.ts
+++ b/src/utils/mapsheet.ts
@@ -360,15 +360,25 @@ export interface ChathamSheetDefinition {
 }
 
 /**
- * Static definition of the six Chatham Islands Topo50 map sheets (EPSG:3793, NZGD2000 / Chatham
- * Islands TM 2000), laid out on the same 24,000m x 36,000m 1:50k grid as the mainland
- * {@link MapSheet}, just with a different origin, CRS, and (small, fixed) set of sheet codes.
+ * The six Chatham Islands Topo50 mapsheets (EPSG:3793, NZGD2000 / Chatham Islands TM 2000),
+ * laid out on the same 24,000m x 36,000m 1:50k grid as the mainland {@link MapSheet},
+ * with a different origin and layout of sheet codes. The following sheet codes are used:
  *
- * "CI" is one of the mainland grid's three missing row codes (see {@link SheetRanges}) precisely
- * because it's reserved for this separate Chatham Islands series - Chatham Islands imagery must
- * not be tiled against the mainland NZTM50 grid.
+ * +------+------+------+
+ * | CI01 | CI02 | CI03 |
+ * |      |      |      |
+ * +------+------+------+
+ *        | CI04 | CI05 |
+ *        |      |      |
+ *        +------+------+
+ *               | CI06 |
+ *               |      |
+ *               +------+
  *
- * Values transcribed from (and can be regenerated with `ogrinfo -al` against):
+ * "CI" is one of the mainland NZ grid's three missing row codes (see {@link SheetRanges})
+ * as it's reserved for the Chatham Islands map sheets.
+ *
+ * Reference:
  * https://data.linz.govt.nz/layer/50089-nz-chatham-island-linz-map-sheets-topo-150k/
  */
 export const ChathamMapSheetData: ChathamSheetDefinition[] = [

--- a/src/utils/mapsheet.ts
+++ b/src/utils/mapsheet.ts
@@ -1,3 +1,5 @@
+import { EpsgCode } from '@basemaps/geo';
+
 /** Parse topographic map sheet names in the format `${mapSheet}_${gridSize}_${y}${x}` */
 const MapSheetRegex = /(?<sheetCode>[A-Z]{2}\d{2})(_(?<gridSize>\d+)_(?<tileId>\d+))?/;
 
@@ -53,12 +55,99 @@ export interface Size {
 }
 export type Bounds = Point & Size;
 
+/**
+ * Common shape of a topographic map sheet grid, so that commands (eg `tileindex-validate`) can
+ * work with more than one grid (eg mainland NZTM50 vs {@link ChathamMapSheet}) without caring
+ * which one they have.
+ */
+export interface MapSheetLike {
+  /** EPSG code of the coordinate reference system this map sheet grid is defined in */
+  crs: number;
+  /** Top left point of the grid the map sheets are laid out on */
+  origin: Point;
+  /** Width of a 1:50k map sheet (meters) */
+  width: number;
+  /** Height of a 1:50k map sheet (meters) */
+  height: number;
+  /** Base (1:50k) scale of the grid (meters) */
+  gridSizeMax: number;
+  /** Allowed grid sizes for sub-tiling a map sheet (meters) */
+  gridSizes: readonly number[];
+  /** Calculate the map sheet code covering a X & Y point */
+  sheetCode(x: number, y: number): string;
+  /** Is this sheet code part of the known range for this grid */
+  isKnown(sheet: string): boolean;
+  /** Get the expected origin and map sheet information from a file name */
+  getMapTileIndex(fileName: string): MapTileIndex | null;
+}
+
 const charA = 'A'.charCodeAt(0);
 const charS = 'S'.charCodeAt(0);
 
 export const MapSheetTileGridSize = 50_000;
 export const GridSizes = [MapSheetTileGridSize, 10_000, 5_000, 2_000, 1_000, 500] as const;
 export type GridSize = (typeof GridSizes)[number];
+
+/**
+ * Shared tile calculation logic between {@link MapSheet} and {@link ChathamMapSheet}: both are
+ * laid out with identical 24,000m x 36,000m 1:50k sheets and sub-tiling scheme, they only differ
+ * in which CRS they're defined in and how a sheet code maps to its origin.
+ *
+ * @param getOffset Look up the top left point of a 1:50k map sheet from its sheet code
+ */
+function computeMapTileIndex(fileName: string, getOffset: (sheetCode: string) => Point): MapTileIndex | null {
+  const match = fileName.match(MapSheetRegex);
+  if (match == null) return null;
+
+  const sheetCode = match?.groups?.['sheetCode'];
+  if (sheetCode == null) return null;
+
+  const gridSize = Number(match?.groups?.['gridSize'] ?? MapSheetTileGridSize);
+  const out: MapTileIndex = {
+    mapSheet: sheetCode,
+    gridSize: gridSize,
+    x: -1,
+    y: -1,
+    name: match[0],
+    origin: { x: 0, y: 0 },
+    width: 0,
+    height: 0,
+    bbox: [0, 0, 0, 0],
+  };
+
+  const mapSheetOffset = getOffset(sheetCode);
+  if (out.gridSize === MapSheetTileGridSize) {
+    out.y = mapSheetOffset.y;
+    out.x = mapSheetOffset.x;
+    out.origin = mapSheetOffset;
+    out.width = MapSheet.width;
+    out.height = MapSheet.height;
+    // As in NZTM negative Y goes north, the minY is actually the bottom right point
+    out.bbox = [out.origin.x, out.origin.y - out.height, out.origin.x + out.width, out.origin.y];
+    return out;
+  }
+
+  // 1:500 has X/Y is 3 digits not 2
+  if (out.gridSize === 500) {
+    out.y = Number(match?.groups?.['tileId']?.slice(0, 3));
+    out.x = Number(match?.groups?.['tileId']?.slice(3));
+  } else {
+    out.y = Number(match?.groups?.['tileId']?.slice(0, 2));
+    out.x = Number(match?.groups?.['tileId']?.slice(2));
+  }
+  if (isNaN(out.gridSize) || isNaN(out.x) || isNaN(out.y)) return null;
+
+  const origin = getOffset(out.mapSheet);
+
+  const tileOffset = MapSheet.tileSize(out.gridSize, out.x, out.y);
+  out.origin.x = origin.x + tileOffset.x;
+  out.origin.y = origin.y - tileOffset.y;
+  out.width = tileOffset.width;
+  out.height = tileOffset.height;
+  // As in NZTM negative Y goes north, the minY is actually the bottom right point
+  out.bbox = [out.origin.x, out.origin.y - tileOffset.height, out.origin.x + tileOffset.width, out.origin.y];
+  return out;
+}
 
 /**
  * Topographic 1:50k map sheet calculator
@@ -77,6 +166,8 @@ export type GridSize = (typeof GridSizes)[number];
  * - https://data.linz.govt.nz/layer/106965-nz-1500-tile-index/ 1:500
  **/
 export const MapSheet = {
+  /** EPSG code of the CRS this map sheet grid is defined in (NZGD2000 / NZTM2000) */
+  crs: EpsgCode.Nztm2000,
   /** Height of Topo 1:50k map sheets (meters) */
   height: 36_000,
   /** Width of Topo 1:50k map sheets (meters) */
@@ -101,57 +192,7 @@ export const MapSheet = {
    * ```
    */
   getMapTileIndex(fileName: string): MapTileIndex | null {
-    const match = fileName.match(MapSheetRegex);
-    if (match == null) return null;
-
-    const sheetCode = match?.groups?.['sheetCode'];
-    if (sheetCode == null) return null;
-
-    const gridSize = Number(match?.groups?.['gridSize'] ?? MapSheetTileGridSize);
-    const out: MapTileIndex = {
-      mapSheet: sheetCode,
-      gridSize: gridSize,
-      x: -1,
-      y: -1,
-      name: match[0],
-      origin: { x: 0, y: 0 },
-      width: 0,
-      height: 0,
-      bbox: [0, 0, 0, 0],
-    };
-
-    const mapSheetOffset = MapSheet.offset(sheetCode);
-    if (out.gridSize === MapSheetTileGridSize) {
-      out.y = mapSheetOffset.y;
-      out.x = mapSheetOffset.x;
-      out.origin = mapSheetOffset;
-      out.width = MapSheet.width;
-      out.height = MapSheet.height;
-      // As in NZTM negative Y goes north, the minY is actually the bottom right point
-      out.bbox = [out.origin.x, out.origin.y - out.height, out.origin.x + out.width, out.origin.y];
-      return out;
-    }
-
-    // 1:500 has X/Y is 3 digits not 2
-    if (out.gridSize === 500) {
-      out.y = Number(match?.groups?.['tileId']?.slice(0, 3));
-      out.x = Number(match?.groups?.['tileId']?.slice(3));
-    } else {
-      out.y = Number(match?.groups?.['tileId']?.slice(0, 2));
-      out.x = Number(match?.groups?.['tileId']?.slice(2));
-    }
-    if (isNaN(out.gridSize) || isNaN(out.x) || isNaN(out.y)) return null;
-
-    const origin = MapSheet.offset(out.mapSheet);
-
-    const tileOffset = MapSheet.tileSize(out.gridSize, out.x, out.y);
-    out.origin.x = origin.x + tileOffset.x;
-    out.origin.y = origin.y - tileOffset.y;
-    out.width = tileOffset.width;
-    out.height = tileOffset.height;
-    // As in NZTM negative Y goes north, the minY is actually the bottom right point
-    out.bbox = [out.origin.x, out.origin.y - tileOffset.height, out.origin.x + tileOffset.width, out.origin.y];
-    return out;
+    return computeMapTileIndex(fileName, (sheetCode) => MapSheet.offset(sheetCode));
   },
   /**
    * Calculate the expected X & Y origin point for a map sheet
@@ -305,3 +346,114 @@ export const SheetRanges = {
   CJ: [[7, 11]],
   CK: [[7, 9]],
 } as const;
+
+/** A single Chatham Islands Topo50 map sheet */
+export interface ChathamSheetDefinition {
+  /** Sheet code, eg "CI06" */
+  code: string;
+  /** Row of the sheet in the Chatham Islands map sheet grid, 0 is the northernmost row */
+  row: number;
+  /** Column of the sheet in the Chatham Islands map sheet grid, 0 is the westernmost column */
+  col: number;
+  /** Top left point of the sheet, in EPSG:3793 */
+  origin: Point;
+}
+
+/**
+ * Static definition of the six Chatham Islands Topo50 map sheets (EPSG:3793, NZGD2000 / Chatham
+ * Islands TM 2000), laid out on the same 24,000m x 36,000m 1:50k grid as the mainland
+ * {@link MapSheet}, just with a different origin, CRS, and (small, fixed) set of sheet codes.
+ *
+ * "CI" is one of the mainland grid's three missing row codes (see {@link SheetRanges}) precisely
+ * because it's reserved for this separate Chatham Islands series - Chatham Islands imagery must
+ * not be tiled against the mainland NZTM50 grid.
+ *
+ * Values transcribed from (and can be regenerated with `ogrinfo -al` against):
+ * https://data.linz.govt.nz/layer/50089-nz-chatham-island-linz-map-sheets-topo-150k/
+ */
+export const ChathamMapSheetData: ChathamSheetDefinition[] = [
+  { code: 'CI01', row: 0, col: 0, origin: { x: 3_458_000, y: 5_176_000 } }, // Point Somes
+  { code: 'CI02', row: 0, col: 1, origin: { x: 3_482_000, y: 5_176_000 } }, // Cape Young
+  { code: 'CI03', row: 0, col: 2, origin: { x: 3_506_000, y: 5_176_000 } }, // Kaingaroa
+  { code: 'CI04', row: 1, col: 1, origin: { x: 3_482_000, y: 5_140_000 } }, // Waitangi
+  { code: 'CI05', row: 1, col: 2, origin: { x: 3_506_000, y: 5_140_000 } }, // Owenga
+  { code: 'CI06', row: 2, col: 2, origin: { x: 3_506_000, y: 5_104_000 } }, // Pitt Island (Rangiauria)
+];
+
+const ChathamSheetByCode = new Map(ChathamMapSheetData.map((s) => [s.code, s]));
+const ChathamSheetByRowCol = new Map(ChathamMapSheetData.map((s) => [`${s.row},${s.col}`, s]));
+
+export const ChathamMapSheet = {
+  /** EPSG code of the CRS this map sheet grid is defined in (NZGD2000 / Chatham Islands TM 2000) */
+  crs: EpsgCode.Citm2000,
+  /** Height of Topo 1:50k map sheets (meters), identical to the mainland grid */
+  height: MapSheet.height,
+  /** Width of Topo 1:50k map sheets (meters), identical to the mainland grid */
+  width: MapSheet.width,
+  /** Top left point of the Chatham Islands map sheet grid, in EPSG:3793 */
+  origin: { x: 3_458_000, y: 5_176_000 },
+  gridSizeMax: MapSheetTileGridSize,
+  gridSizes: GridSizes,
+
+  /** Get the expected origin and map sheet information from a file name */
+  getMapTileIndex(fileName: string): MapTileIndex | null {
+    return computeMapTileIndex(fileName, (sheetCode) => ChathamMapSheet.offset(sheetCode));
+  },
+
+  /**
+   * Get the expected origin for a Chatham Islands sheet code
+   *
+   * @example
+   * ```typescript
+   * ChathamMapSheet.offset("CI06") // { x: 3506000, y: 5104000 }
+   * ```
+   */
+  offset(sheetCode: string): Point {
+    const sheet = ChathamSheetByCode.get(sheetCode.slice(0, 4));
+    if (sheet != null) return sheet.origin;
+    // Outside the six known sheets, there is nothing sensible to compute - fall back to the grid
+    // origin so callers get a usable (if geographically meaningless) point rather than crashing;
+    // `isKnown()` will flag the sheet code so this is visible in logs.
+    return ChathamMapSheet.origin;
+  },
+
+  /**
+   * Calculate the Chatham Islands sheet code from an EPSG:3793 X & Y point
+   *
+   * @warning this does **not** ensure the sheet code is inside the expected range see {@link ChathamMapSheet.isKnown}
+   */
+  sheetCode(x: number, y: number): string {
+    const col = Math.floor((x - ChathamMapSheet.origin.x) / ChathamMapSheet.width);
+    const row = Math.floor((ChathamMapSheet.origin.y - y) / ChathamMapSheet.height);
+    const sheet = ChathamSheetByRowCol.get(`${row},${col}`);
+    if (sheet != null) return sheet.code;
+    // Not one of the six known sheets; synthesize a code so callers get a parseable string, `isKnown()` will flag it.
+    return `CI${Math.abs(row) % 10}${Math.abs(col) % 10}`;
+  },
+
+  /** Is this one of the six known Chatham Islands map sheets */
+  isKnown(sheet: string): boolean {
+    return ChathamSheetByCode.has(sheet.slice(0, 4));
+  },
+};
+
+/** Registry of the map sheet grids supported by `tileindex-validate`, keyed by their EPSG code */
+export const MapSheetRegistry: Record<number, MapSheetLike> = {
+  [MapSheet.crs]: MapSheet,
+  [ChathamMapSheet.crs]: ChathamMapSheet,
+};
+
+/**
+ * Get the map sheet grid to use for a given target EPSG code
+ *
+ * @throws if the EPSG code is not one of the supported map sheet grids
+ */
+export function getMapSheet(epsg: number): MapSheetLike {
+  const mapSheet = MapSheetRegistry[epsg];
+  if (mapSheet == null) {
+    throw new Error(
+      `Unsupported target EPSG:${epsg}; supported target EPSG codes: ${Object.keys(MapSheetRegistry).join(', ')}`,
+    );
+  }
+  return mapSheet;
+}

--- a/src/utils/mapsheet.ts
+++ b/src/utils/mapsheet.ts
@@ -61,6 +61,8 @@ export type Bounds = Point & Size;
  * which one they have.
  */
 export interface MapSheetLike {
+  /** Human readable name of this map sheet grid, eg "NZTM2000" or "Chatham Islands" */
+  name: string;
   /** EPSG code of the coordinate reference system this map sheet grid is defined in */
   crs: number;
   /** Top left point of the grid the map sheets are laid out on */
@@ -166,6 +168,8 @@ function computeMapTileIndex(fileName: string, getOffset: (sheetCode: string) =>
  * - https://data.linz.govt.nz/layer/106965-nz-1500-tile-index/ 1:500
  **/
 export const MapSheet = {
+  /** Human readable name of this map sheet grid */
+  name: 'NZTM2000',
   /** EPSG code of the CRS this map sheet grid is defined in (NZGD2000 / NZTM2000) */
   crs: EpsgCode.Nztm2000,
   /** Height of Topo 1:50k map sheets (meters) */
@@ -394,6 +398,8 @@ const ChathamSheetByCode = new Map(ChathamMapSheetData.map((s) => [s.code, s]));
 const ChathamSheetByRowCol = new Map(ChathamMapSheetData.map((s) => [`${s.row},${s.col}`, s]));
 
 export const ChathamMapSheet = {
+  /** Human readable name of this map sheet grid */
+  name: 'Chatham Islands',
   /** EPSG code of the CRS this map sheet grid is defined in (NZGD2000 / Chatham Islands TM 2000) */
   crs: EpsgCode.Citm2000,
   /** Height of Topo 1:50k map sheets (meters), identical to the mainland grid */

--- a/src/utils/mapsheet.ts
+++ b/src/utils/mapsheet.ts
@@ -57,8 +57,8 @@ export type Bounds = Point & Size;
 
 /**
  * Common shape of a topographic map sheet grid, so that commands (eg `tileindex-validate`) can
- * work with more than one grid (eg mainland NZTM50 vs {@link ChathamMapSheet}) without caring
- * which one they have.
+ * work with more than one grid (eg mainland NZTM50 {@link MapSheet} vs {@link ChathamMapSheet})
+ * without caring which one they have.
  */
 export interface MapSheetLike {
   /** Human readable name of this map sheet grid, eg "NZTM2000" or "Chatham Islands" */
@@ -92,8 +92,7 @@ export type GridSize = (typeof GridSizes)[number];
 
 /**
  * Shared tile calculation logic between {@link MapSheet} and {@link ChathamMapSheet}: both are
- * laid out with identical 24,000m x 36,000m 1:50k sheets and sub-tiling scheme, they only differ
- * in which CRS they're defined in and how a sheet code maps to its origin.
+ * laid out with 24,000m x 36,000m 1:50k sheets and tiling schemes, they only differ in the CRS.
  *
  * @param getOffset Look up the top left point of a 1:50k map sheet from its sheet code
  */
@@ -399,12 +398,12 @@ const ChathamSheetByRowCol = new Map(ChathamMapSheetData.map((s) => [`${s.row},$
 
 export const ChathamMapSheet = {
   /** Human readable name of this map sheet grid */
-  name: 'Chatham Islands',
+  name: 'CITM2000',
   /** EPSG code of the CRS this map sheet grid is defined in (NZGD2000 / Chatham Islands TM 2000) */
   crs: EpsgCode.Citm2000,
-  /** Height of Topo 1:50k map sheets (meters), identical to the mainland grid */
+  /** Height of Topo 1:50k map sheets (meters), same as the mainland grid */
   height: MapSheet.height,
-  /** Width of Topo 1:50k map sheets (meters), identical to the mainland grid */
+  /** Width of Topo 1:50k map sheets (meters), same as the mainland grid */
   width: MapSheet.width,
   /** Top left point of the Chatham Islands map sheet grid, in EPSG:3793 */
   origin: { x: 3_458_000, y: 5_176_000 },
@@ -423,14 +422,14 @@ export const ChathamMapSheet = {
    * ```typescript
    * ChathamMapSheet.offset("CI06") // { x: 3506000, y: 5104000 }
    * ```
+   * @throws if the sheet code is not one of the six known Chatham Islands sheets, see {@link ChathamMapSheet.isKnown}
    */
   offset(sheetCode: string): Point {
     const sheet = ChathamSheetByCode.get(sheetCode.slice(0, 4));
-    if (sheet != null) return sheet.origin;
-    // Outside the six known sheets, there is nothing sensible to compute - fall back to the grid
-    // origin so callers get a usable (if geographically meaningless) point rather than crashing;
-    // `isKnown()` will flag the sheet code so this is visible in logs.
-    return ChathamMapSheet.origin;
+    if (sheet == null) {
+      throw new Error(`Unknown Chatham Islands map sheet "${sheetCode}"; not one of the six known sheets`);
+    }
+    return sheet.origin;
   },
 
   /**

--- a/src/utils/mapsheet.ts
+++ b/src/utils/mapsheet.ts
@@ -77,6 +77,8 @@ export interface MapSheetLike {
   gridSizes: readonly number[];
   /** Calculate the map sheet code covering a X & Y point */
   sheetCode(x: number, y: number): string;
+  /** Get the expected origin for a map sheet code */
+  offset(sheetCode: string): Point;
   /** Is this sheet code part of the known range for this grid */
   isKnown(sheet: string): boolean;
   /** Get the expected origin and map sheet information from a file name */
@@ -92,11 +94,13 @@ export type GridSize = (typeof GridSizes)[number];
 
 /**
  * Shared tile calculation logic between {@link MapSheet} and {@link ChathamMapSheet}: both are
- * laid out with 24,000m x 36,000m 1:50k sheets and tiling schemes, they only differ in the CRS.
+ * laid out with 24,000m x 36,000m 1:50k sheets and tiling schemes, they only differ in the CRS
+ * and how a sheet code maps to its origin.
  *
- * @param getOffset Look up the top left point of a 1:50k map sheet from its sheet code
+ * @param mapSheet The grid `fileName`'s sheet code belongs to; its own `width`/`height`/`offset`
+ * are used so this works correctly for any registered grid, not just the mainland one.
  */
-function computeMapTileIndex(fileName: string, getOffset: (sheetCode: string) => Point): MapTileIndex | null {
+function computeMapTileIndex(fileName: string, mapSheet: MapSheetLike): MapTileIndex | null {
   const match = fileName.match(MapSheetRegex);
   if (match == null) return null;
 
@@ -116,13 +120,13 @@ function computeMapTileIndex(fileName: string, getOffset: (sheetCode: string) =>
     bbox: [0, 0, 0, 0],
   };
 
-  const mapSheetOffset = getOffset(sheetCode);
+  const mapSheetOffset = mapSheet.offset(sheetCode);
   if (out.gridSize === MapSheetTileGridSize) {
     out.y = mapSheetOffset.y;
     out.x = mapSheetOffset.x;
     out.origin = mapSheetOffset;
-    out.width = MapSheet.width;
-    out.height = MapSheet.height;
+    out.width = mapSheet.width;
+    out.height = mapSheet.height;
     // As in NZTM negative Y goes north, the minY is actually the bottom right point
     out.bbox = [out.origin.x, out.origin.y - out.height, out.origin.x + out.width, out.origin.y];
     return out;
@@ -138,9 +142,9 @@ function computeMapTileIndex(fileName: string, getOffset: (sheetCode: string) =>
   }
   if (isNaN(out.gridSize) || isNaN(out.x) || isNaN(out.y)) return null;
 
-  const origin = getOffset(out.mapSheet);
+  const origin = mapSheet.offset(out.mapSheet);
 
-  const tileOffset = MapSheet.tileSize(out.gridSize, out.x, out.y);
+  const tileOffset = computeTileSize(mapSheet, out.gridSize, out.x, out.y);
   out.origin.x = origin.x + tileOffset.x;
   out.origin.y = origin.y - tileOffset.y;
   out.width = tileOffset.width;
@@ -148,6 +152,19 @@ function computeMapTileIndex(fileName: string, getOffset: (sheetCode: string) =>
   // As in NZTM negative Y goes north, the minY is actually the bottom right point
   out.bbox = [out.origin.x, out.origin.y - tileOffset.height, out.origin.x + tileOffset.width, out.origin.y];
   return out;
+}
+
+/** Generate the size of a tile inside a map sheet at a specific grid size */
+function computeTileSize(
+  mapSheet: Pick<MapSheetLike, 'width' | 'height' | 'gridSizeMax'>,
+  gridSize: number,
+  x: number,
+  y: number,
+): Bounds {
+  const scale = gridSize / mapSheet.gridSizeMax;
+  const offsetX = mapSheet.width * scale;
+  const offsetY = mapSheet.height * scale;
+  return { x: (x - 1) * offsetX, y: (y - 1) * offsetY, width: offsetX, height: offsetY };
 }
 
 /**
@@ -195,7 +212,7 @@ export const MapSheet = {
    * ```
    */
   getMapTileIndex(fileName: string): MapTileIndex | null {
-    return computeMapTileIndex(fileName, (sheetCode) => MapSheet.offset(sheetCode));
+    return computeMapTileIndex(fileName, MapSheet);
   },
   /**
    * Calculate the expected X & Y origin point for a map sheet
@@ -261,10 +278,7 @@ export const MapSheet = {
 
   /** Generate the size of tile inside a map sheet at a specific grid size */
   tileSize(gridSize: number, x: number, y: number): Bounds {
-    const scale = gridSize / MapSheet.scale;
-    const offsetX = MapSheet.width * scale;
-    const offsetY = MapSheet.height * scale;
-    return { x: (x - 1) * offsetX, y: (y - 1) * offsetY, width: offsetX, height: offsetY };
+    return computeTileSize(MapSheet, gridSize, x, y);
   },
 
   /**
@@ -412,7 +426,7 @@ export const ChathamMapSheet = {
 
   /** Get the expected origin and map sheet information from a file name */
   getMapTileIndex(fileName: string): MapTileIndex | null {
-    return computeMapTileIndex(fileName, (sheetCode) => ChathamMapSheet.offset(sheetCode));
+    return computeMapTileIndex(fileName, ChathamMapSheet);
   },
 
   /**
@@ -442,8 +456,11 @@ export const ChathamMapSheet = {
     const row = Math.floor((ChathamMapSheet.origin.y - y) / ChathamMapSheet.height);
     const sheet = ChathamSheetByRowCol.get(`${row},${col}`);
     if (sheet != null) return sheet.code;
-    // Not one of the six known sheets; synthesize a code so callers get a parseable string, `isKnown()` will flag it.
-    return `CI${Math.abs(row) % 10}${Math.abs(col) % 10}`;
+    // Not one of the six known sheets; synthesize a parseable code for logs. The six real codes
+    // are always "CI0X" (X 1-6), so the tens digit is kept in 1-9 here to guarantee this can
+    // never be mistaken for a real sheet by isKnown()/offset() - two different invalid cells can
+    // still synthesize the same code, but that's just log-label ambiguity, not a silent mis-tiling risk.
+    return `CI${(Math.abs(row) % 9) + 1}${Math.abs(col) % 10}`;
   },
 
   /** Is this one of the six known Chatham Islands map sheets */


### PR DESCRIPTION
### Motivation

In order to standardise Chatham Islands datasets, EPSG 3793 (CITM2000) needs to be accepted and the relevant map sheet origins supported.

### Modifications

Look up table for Chatham Islands map sheets, adding support for EPSG 3793.

### Verification

Unit tests and workflow run.
